### PR TITLE
Add template defs for rest of stdlib

### DIFF
--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -14,11 +14,11 @@
   <typedef name="boolean" zero="false" one="true"/>
   <typedef name="integer" zero="0" one="1"/>
   <typedef name="float" zero="0.0" one="1.0" half="0.5" />
-  <typedef name="color3" semantic="color" zero="0.0,0.0,0.0" one="1.0,1.0,1.0" half="0.5,0.5,0.5" />
-  <typedef name="color4" semantic="color" zero="0.0,0.0,0.0,0.0" one="1.0,1.0,1.0,1.0" half="0.5,0.5,0.5,0.5" />
-  <typedef name="vector2" zero="0.0,0.0" one="1.0,1.0" half="0.5,0.5,0.5" />
-  <typedef name="vector3" zero="0.0,0.0,0.0" one="1.0,1.0,1.0" half="0.5,0.5,0.5" />
-  <typedef name="vector4" zero="0.0,0.0,0.0,0.0" one="1.0,1.0,1.0,1.0" half="0.5,0.5,0.5,0.5" />
+  <typedef name="color3" semantic="color" zero="0.0, 0.0, 0.0" one="1.0, 1.0, 1.0" half="0.5, 0.5, 0.5" />
+  <typedef name="color4" semantic="color" zero="0.0, 0.0, 0.0, 0.0" one="1.0, 1.0, 1.0, 1.0" half="0.5, 0.5, 0.5, 0.5" />
+  <typedef name="vector2" zero="0.0, 0.0" one="1.0, 1.0" half="0.5, 0.5" />
+  <typedef name="vector3" zero="0.0, 0.0, 0.0" one="1.0, 1.0, 1.0" half="0.5, 0.5, 0.5" />
+  <typedef name="vector4" zero="0.0, 0.0, 0.0, 0.0" one="1.0, 1.0, 1.0, 1.0" half="0.5, 0.5, 0.5, 0.5" />
   <typedef name="matrix33" zero="0.0,0.0,0.0, 0.0,0.0,0.0, 0.0,0.0,0.0" one="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
   <typedef name="matrix44" zero="0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0" one="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
   <typedef name="string" zero="" />
@@ -135,7 +135,7 @@
       <input name="framerange" type="string" value="" uiname="Frame Range" uniform="true" />
       <input name="frameoffset" type="integer" value="0" uiname="Frame Offset" uniform="true" />
       <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action" uniform="true" />
-      <output name="out" type="float" default="Value:zero" />
+      <output name="out" type="@typeName@" default="Value:zero" />
     </nodedef>
   </template>
 
@@ -181,7 +181,7 @@
       <input name="falloff" type="float" value="0.5" />
       <input name="falloffcontrast" type="float" value="0.5" />
       <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" />
-      <output name="out" type="@typeName@" default="@Value:zero" />
+      <output name="out" type="@typeName@" default="Value:zero" />
     </nodedef>
   </template>
 
@@ -221,9 +221,16 @@
     A constant value. When exposed as a public parameter, this is a way to create a
     value that can be accessed in multiple places in the opgraph.
   -->
-  <template name="TP_ND_constant" varName="typeName" options="float, color3, color4, vector2, vector3, vector4, boolean, integer, string, filename">
+  <template name="TP_ND_constant" varName="typeName" options="float, color3, color4, vector2, vector3, vector4, boolean, integer">
     <nodedef name="ND_constant_@typeName@" node="constant" nodegroup="procedural">
       <input name="value" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
+
+  <template name="TP_ND_constant_uniform" varName="typeName" options="string, filename">
+    <nodedef name="ND_constant_@typeName@" node="constant" nodegroup="procedural">
+      <input name="value" type="@typeName@" value="Value:zero" uniform="true" />
       <output name="out" type="@typeName@" default="Value:zero" />
     </nodedef>
   </template>
@@ -333,6 +340,20 @@
     <nodedef name="ND_splitlr_@typeName@" node="splitlr" nodegroup="procedural2d">
       <input name="valuel" type="@typeName@" value="Value:zero" uiname="Left" />
       <input name="valuer" type="@typeName@" value="Value:zero" uiname="Right" />
+      <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
+      <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
+
+  <!--
+    Node: <splittb>
+    A top-bottom split matte, split at a specified v value.
+  -->
+  <template name="TP_ND_splittb" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_splittb_@typeName@" node="splittb" nodegroup="procedural2d">
+      <input name="valuet" type="@typeName@" value="Value:zero" uiname="Top" />
+      <input name="valueb" type="@typeName@" value="Value:zero" uiname="Bottom" />
       <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
       <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
       <output name="out" type="@typeName@" default="Value:zero" />
@@ -1003,7 +1024,7 @@
     Node: <fract>
     The fraction of a float or vector.
   -->
-  <template name="TP_ND_modulo" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+  <template name="TP_ND_fract" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
     <nodedef name="ND_fract_@typeName@" node="fract" nodegroup="math">
       <input name="in" type="@typeName@" value="Value:zero" />
       <output name="out" type="@typeName@" defaultinput="in" />
@@ -1017,16 +1038,16 @@
   -->
   <template name="TP_ND_invert" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
     <nodedef name="ND_invert_@typeName@" node="invert" nodegroup="math">
-      <input name="in1" type="@typeName@" value="Value:zero" />
-      <input name="in2" type="@typeName@" value="Value:one" />
-      <output name="out" type="@typeName@" defaultinput="in1" />
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="amount" type="@typeName@" value="Value:one" />
+      <output name="out" type="@typeName@" defaultinput="in" />
     </nodedef>
   </template>
   <template name="TP_ND_invertFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
     <nodedef name="ND_invert_@typeName@FA" node="invert" nodegroup="math">
-      <input name="in1" type="@typeName@" value="Value:zero" />
-      <input name="in2" type="float" value="1.0" />
-      <output name="out" type="@typeName@" defaultinput="in1" />
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="amount" type="float" value="1.0" />
+      <output name="out" type="@typeName@" defaultinput="in" />
     </nodedef>
   </template>
 
@@ -1283,10 +1304,10 @@
     Node: <magnitude>
     Outputs the float magnitude (vector length) of the incoming vector stream.
   -->
-  <template name="TP_ND_normalize" varName="typeName" options="vector2, vector3, vector4">
-    <nodedef name="ND_normalize_@typeName@" node="normalize" nodegroup="math">
+  <template name="TP_ND_magnitude" varName="typeName" options="vector2, vector3, vector4">
+    <nodedef name="ND_magnitude_@typeName@" node="magnitude" nodegroup="math">
       <input name="in" type="@typeName@" value="Value:zero" />
-      <output name="out" type="float" defaultinput="in" />
+      <output name="out" type="float" default="0.0" />
     </nodedef>
   </template>
 
@@ -1296,9 +1317,9 @@
   -->
   <template name="TP_ND_distance" varName="typeName" options="vector2, vector3, vector4">
     <nodedef name="ND_distance_@typeName@" node="distance" nodegroup="math">
-      <input name="in1" type="@typeName@" value="Value:zero" />
-      <input name="in2" type="@typeName@" value="Value:zero" />
-      <output name="out" type="float" defaultinput="in1" />
+      <input name="in1" type="@typeName@" value="Value:zero" uiname="in1" />
+      <input name="in2" type="@typeName@" value="Value:zero" uiname="in2" />
+      <output name="out" type="float" />
     </nodedef>
   </template>
 
@@ -1310,7 +1331,7 @@
     <nodedef name="ND_dotproduct_@typeName@" node="dotproduct" nodegroup="math">
       <input name="in1" type="@typeName@" value="Value:zero" />
       <input name="in2" type="@typeName@" value="Value:zero" />
-      <output name="out" type="float" defaultinput="in1" />
+      <output name="out" type="float" default="0.0" />
     </nodedef>
   </template>
 
@@ -1543,7 +1564,7 @@
     Remap a value from one range of float/color/vector values to another.
   -->
   <template name="TP_ND_remap" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
-    <nodedef name="ND_remap_@typeName@" node="remap" nodegroup="math">
+    <nodedef name="ND_remap_@typeName@" node="remap" nodegroup="adjustment">
       <input name="in" type="@typeName@" value="Value:zero" />
       <input name="inlow" type="@typeName@" value="Value:zero" />
       <input name="inhigh" type="@typeName@" value="Value:one" />
@@ -1554,7 +1575,7 @@
   </template>
 
   <template name="TP_ND_remapFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
-    <nodedef name="ND_remap_@typeName@FA" node="remap" nodegroup="math">
+    <nodedef name="ND_remap_@typeName@FA" node="remap" nodegroup="adjustment">
       <input name="in" type="@typeName@" value="Value:zero" />
       <input name="inlow" type="float" value="0.0" />
       <input name="inhigh" type="float" value="1.0" />
@@ -1570,7 +1591,7 @@
     to output 0-1.
   -->
   <template name="TP_ND_smoothstep" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
-    <nodedef name="ND_smoothstep_@typeName@" node="smoothstep" nodegroup="math">
+    <nodedef name="ND_smoothstep_@typeName@" node="smoothstep" nodegroup="adjustment">
       <input name="in" type="@typeName@" value="Value:zero" />
       <input name="low" type="@typeName@" value="Value:zero" />
       <input name="high" type="@typeName@" value="Value:one" />
@@ -1579,7 +1600,7 @@
   </template>
 
   <template name="TP_ND_smoothstepFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
-    <nodedef name="ND_smoothstep_@typeName@FA" node="smoothstep" nodegroup="math">
+    <nodedef name="ND_smoothstep_@typeName@FA" node="smoothstep" nodegroup="adjustment">
       <input name="in" type="@typeName@" value="Value:zero" />
       <input name="low" type="float" value="0.0" />
       <input name="high" type="float" value="1.0" />
@@ -1594,7 +1615,7 @@
     the alpha channel is left unchanged if present.
   -->
   <template name="TP_ND_luminance" varName="typeName" options="color3, color4">
-    <nodedef name="ND_luminance_@typeName@" node="luminance" nodegroup="math">
+    <nodedef name="ND_luminance_@typeName@" node="luminance" nodegroup="adjustment">
       <input name="in" type="@typeName@" value="Value:zero" />
       <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" />
       <output name="out" type="@typeName@" defaultinput="in" />
@@ -1606,13 +1627,13 @@
     Convert an incoming color between RGB and HSV space, with H and S ranging from 0-1.
   -->
   <template name="TP_ND_rgbtohsv" varName="typeName" options="color3, color4">
-    <nodedef name="ND_rgbtohsv_@typeName@" node="rgbtohsv" nodegroup="math">
+    <nodedef name="ND_rgbtohsv_@typeName@" node="rgbtohsv" nodegroup="adjustment">
       <input name="in" type="@typeName@" value="Value:zero" />
       <output name="out" type="@typeName@" defaultinput="in" />
     </nodedef>
   </template>
   <template name="TP_ND_hsvtorgb" varName="typeName" options="color3, color4">
-    <nodedef name="ND_hsvtorgb_@typeName@" node="hsvtorgb" nodegroup="math">
+    <nodedef name="ND_hsvtorgb_@typeName@" node="hsvtorgb" nodegroup="adjustment">
       <input name="in" type="@typeName@" value="Value:zero" />
       <output name="out" type="@typeName@" defaultinput="in" />
     </nodedef>
@@ -1623,7 +1644,7 @@
     Increase or decrease contrast of a float/color value using a linear slope multiplier.
   -->
   <template name="TP_ND_contrast" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
-    <nodedef name="ND_contrast_@typeName@" node="contrast" nodegroup="math">
+    <nodedef name="ND_contrast_@typeName@" node="contrast" nodegroup="adjustment">
       <input name="in" type="@typeName@" value="Value:zero" />
       <input name="amount" type="@typeName@" value="Value:one" />
       <input name="pivot" type="@typeName@" value="Value:half" />
@@ -1632,7 +1653,7 @@
   </template>
 
   <template name="TP_ND_contrastFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
-    <nodedef name="ND_contrast_@typeName@FA" node="contrast" nodegroup="math">
+    <nodedef name="ND_contrast_@typeName@FA" node="contrast" nodegroup="adjustment">
       <input name="in" type="@typeName@" value="Value:zero" />
       <input name="amount" type="float" value="1.0" />
       <input name="pivot" type="float" value="0.5" />
@@ -1646,7 +1667,7 @@
     applying a gamma correction in the middle, and optionally clamping output values.
   -->
   <template name="TP_ND_range" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
-    <nodedef name="ND_range_@typeName@" node="range" nodegroup="math">
+    <nodedef name="ND_range_@typeName@" node="range" nodegroup="adjustment">
       <input name="in" type="@typeName@" value="Value:zero" />
       <input name="inlow" type="@typeName@" value="Value:zero" />
       <input name="inhigh" type="@typeName@" value="Value:one" />
@@ -1659,7 +1680,7 @@
   </template>
 
   <template name="TP_ND_rangeFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
-    <nodedef name="ND_range_@typeName@FA" node="range" nodegroup="math">
+    <nodedef name="ND_range_@typeName@FA" node="range" nodegroup="adjustment">
       <input name="in" type="@typeName@" value="Value:zero" />
       <input name="inlow" type="float" value="0.0" />
       <input name="inhigh" type="float" value="1.0" />
@@ -1678,7 +1699,7 @@
     multiplying the value by amount.z, then converting back to RGB.
   -->
   <template name="TP_ND_hsvadjust" varName="typeName" options="color3, color4">
-    <nodedef name="ND_hsvadjust_@typeName@" node="hsvadjust" nodegroup="math">
+    <nodedef name="ND_hsvadjust_@typeName@" node="hsvadjust" nodegroup="adjustment">
       <input name="in" type="@typeName@" value="Value:zero" />
       <input name="amount" type="vector3" value="0.0, 1.0, 1.0" />
       <output name="out" type="@typeName@" defaultinput="in" />
@@ -1692,7 +1713,7 @@
     coefficients; the alpha channel will be unchanged if present.
   -->
   <template name="TP_ND_saturate" varName="typeName" options="color3, color4">
-    <nodedef name="ND_saturate_@typeName@" node="saturate" nodegroup="math">
+    <nodedef name="ND_saturate_@typeName@" node="saturate" nodegroup="adjustment">
       <input name="in" type="@typeName@" value="Value:zero" />
       <input name="amount" type="float" value="1.0" />
       <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" />
@@ -1920,7 +1941,7 @@
   <template name="TP_ND_inside" varName="typeName" options="float, color3, color4">
     <nodedef name="ND_inside_@typeName@" node="inside" nodegroup="compositing">
       <input name="in" type="@typeName@" value="Value:zero" />
-      <input name="mask" type="@typeName@" value="Value:one" />
+      <input name="mask" type="float" value="1.0" />
       <output name="out" type="@typeName@" defaultinput="in" />
     </nodedef>
   </template>
@@ -1933,7 +1954,7 @@
   <template name="TP_ND_outside" varName="typeName" options="float, color3, color4">
     <nodedef name="ND_outside_@typeName@" node="outside" nodegroup="compositing">
       <input name="in" type="@typeName@" value="Value:zero" />
-      <input name="mask" type="@typeName@" value="Value:zero" />
+      <input name="mask" type="float" value="0.0" />
       <output name="out" type="@typeName@" defaultinput="in" />
     </nodedef>
   </template>
@@ -1955,7 +1976,7 @@
     <nodedef name="ND_mix_@typeName@_@typeName@" node="mix" nodegroup="compositing">
       <input name="fg" type="@typeName@" value="Value:zero" />
       <input name="bg" type="@typeName@" value="Value:zero" />
-      <input name="mix" type="@typeName@" value="Value:zero" uisoftmin="0,0,0" uisoftmax="1,1,1" />
+      <input name="mix" type="@typeName@" value="Value:zero" uisoftmin="Value:zero" uisoftmax="Value:one" />
       <output name="out" type="@typeName@" defaultinput="bg" />
     </nodedef>
   </template>
@@ -1968,17 +1989,23 @@
     Node: <ifgreater>
     Output the value of in1 if value1>value2, or the value of in2 if value1<=value2.
   -->
-  <template name="TP_ND_ifgreater" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4, matrix33, matrix44, boolean">
+  <template name="TP_ND_ifgreater" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4, matrix33, matrix44">
     <nodedef name="ND_ifgreater_@typeName@" node="ifgreater" nodegroup="conditional">
       <input name="value1" type="float" value="1.0" />
       <input name="value2" type="float" value="0.0" />
-      <input name="in1" type="@typeName@" value="0.0" />
-      <input name="in2" type="@typeName@" value="0.0" />
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:zero" />
       <output name="out" type="@typeName@" defaultinput="in1" />
     </nodedef>
   </template>
 
-  <template name="TP_ND_ifgreater_I" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4, matrix33, matrix44, boolean">
+  <nodedef name="ND_ifgreater_boolean" node="ifgreater" nodegroup="conditional">
+    <input name="value1" type="float" value="1.0" />
+    <input name="value2" type="float" value="0.0" />
+    <output name="out" type="boolean" default="false" />
+  </nodedef>
+
+  <template name="TP_ND_ifgreater_I" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4, matrix33, matrix44">
     <nodedef name="ND_ifgreater_@typeName@I" node="ifgreater" nodegroup="conditional">
       <input name="value1" type="integer" value="1" />
       <input name="value2" type="integer" value="0" />
@@ -1988,21 +2015,33 @@
     </nodedef>
   </template>
 
+  <nodedef name="ND_ifgreater_booleanI" node="ifgreater" nodegroup="conditional">
+    <input name="value1" type="integer" value="1" />
+    <input name="value2" type="integer" value="0" />
+    <output name="out" type="boolean" default="false" />
+  </nodedef>
+
   <!--
     Node: <ifgreatereq>
     Output the value of in1 if value1>=value2, or the value of in2 if value1<value2.
   -->
-  <template name="TP_ND_ifgreatereq" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4, matrix33, matrix44, boolean">
+  <template name="TP_ND_ifgreatereq" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4, matrix33, matrix44">
     <nodedef name="ND_ifgreatereq_@typeName@" node="ifgreatereq" nodegroup="conditional">
       <input name="value1" type="float" value="1.0" />
       <input name="value2" type="float" value="0.0" />
-      <input name="in1" type="@typeName@" value="0.0" />
-      <input name="in2" type="@typeName@" value="0.0" />
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:zero" />
       <output name="out" type="@typeName@" defaultinput="in1" />
     </nodedef>
   </template>
 
-  <template name="TP_ND_ifgreatereq_I" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4, matrix33, matrix44, boolean">
+  <nodedef name="ND_ifgreatereq_boolean" node="ifgreatereq" nodegroup="conditional">
+    <input name="value1" type="float" value="1.0" />
+    <input name="value2" type="float" value="0.0" />
+    <output name="out" type="boolean" default="false" />
+  </nodedef>
+
+  <template name="TP_ND_ifgreatereq_I" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4, matrix33, matrix44">
     <nodedef name="ND_ifgreatereq_@typeName@I" node="ifgreatereq" nodegroup="conditional">
       <input name="value1" type="integer" value="1" />
       <input name="value2" type="integer" value="0" />
@@ -2012,21 +2051,33 @@
     </nodedef>
   </template>
 
+  <nodedef name="ND_ifgreatereq_booleanI" node="ifgreatereq" nodegroup="conditional">
+    <input name="value1" type="integer" value="1" />
+    <input name="value2" type="integer" value="0" />
+    <output name="out" type="boolean" default="false" />
+  </nodedef>
+
   <!--
     Node: <ifequal>
     Output the value of in1 if value1==value2, or the value of in2 if value1!=value2.
   -->
-  <template name="TP_ND_ifequal" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4, matrix33, matrix44, boolean">
+  <template name="TP_ND_ifequal" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4, matrix33, matrix44">
     <nodedef name="ND_ifequal_@typeName@" node="ifequal" nodegroup="conditional">
       <input name="value1" type="float" value="0.0" />
       <input name="value2" type="float" value="0.0" />
-      <input name="in1" type="@typeName@" value="0.0" />
-      <input name="in2" type="@typeName@" value="0.0" />
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:zero" />
       <output name="out" type="@typeName@" defaultinput="in1" />
     </nodedef>
   </template>
 
-  <template name="TP_ND_ifequal_I" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4, matrix33, matrix44, boolean">
+  <nodedef name="ND_ifequal_boolean" node="ifequal" nodegroup="conditional">
+    <input name="value1" type="float" value="1.0" />
+    <input name="value2" type="float" value="0.0" />
+    <output name="out" type="boolean" default="false" />
+  </nodedef>
+
+  <template name="TP_ND_ifequal_I" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4, matrix33, matrix44">
     <nodedef name="ND_ifequal_@typeName@I" node="ifequal" nodegroup="conditional">
       <input name="value1" type="integer" value="0" />
       <input name="value2" type="integer" value="0" />
@@ -2035,6 +2086,28 @@
       <output name="out" type="@typeName@" defaultinput="in1" />
     </nodedef>
   </template>
+
+  <nodedef name="ND_ifequal_booleanI" node="ifequal" nodegroup="conditional">
+    <input name="value1" type="integer" value="1" />
+    <input name="value2" type="integer" value="0" />
+    <output name="out" type="boolean" default="false" />
+  </nodedef>
+
+  <template name="TP_ND_ifequal_B" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4, matrix33, matrix44">
+    <nodedef name="ND_ifequal_@typeName@B" node="ifequal" nodegroup="conditional">
+      <input name="value1" type="boolean" value="false" />
+      <input name="value2" type="boolean" value="false" />
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+
+  <nodedef name="ND_ifequal_booleanB" node="ifequal" nodegroup="conditional">
+    <input name="value1" type="boolean" value="false" />
+    <input name="value2" type="boolean" value="false" />
+    <output name="out" type="boolean" default="false" />
+  </nodedef>
 
   <!--
     Node: <switch>
@@ -2087,7 +2160,7 @@
   <template name="TP_ND_convert_float" varName="typeName" options="color3, color4, vector2, vector3, vector4">
     <nodedef name="ND_convert_float_@typeName@" node="convert" nodegroup="channel">
       <input name="in" type="float" value="0.0" />
-      <output name="out" type="@typeName@" default="Value:0" />
+      <output name="out" type="@typeName@" default="Value:zero" />
     </nodedef>
   </template>
 
@@ -2192,7 +2265,7 @@
     Combine the channels from four streams into the same number of channels of a
     single output stream of a specified compatible type.
   -->
-  <template name="TP_ND_combine3" varName="typeName" options="color4, vector4">
+  <template name="TP_ND_combine4" varName="typeName" options="color4, vector4">
     <nodedef name="ND_combine4_@typeName@" node="combine4" nodegroup="channel">
       <input name="in1" type="float" value="0.0" />
       <input name="in2" type="float" value="0.0" />
@@ -2233,13 +2306,32 @@
     Node: <extract>
     Extract a single channel from a colorN or vectorN stream, outputting a float.
   -->
-  <template name="TP_ND_extract" varName="typeName" options="color3, color4, vector2, vector3, vector4">
-    <nodedef name="ND_extract_@typeName@" node="extract" nodegroup="channel">
-      <input name="in" type="@typeName@" value="Value:zero" />
-      <input name="index" type="integer" value="0" uimin="0" uimax="2" uniform="true" />
-      <output name="out" type="float" default="0.0" />
-    </nodedef>
-  </template>
+  <nodedef name="ND_extract_color3" node="extract" nodegroup="channel">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="index" type="integer" value="0" uimin="0" uimax="2" uniform="true" />
+    <output name="out" type="float" default="0.0" />
+  </nodedef>
+  <nodedef name="ND_extract_color4" node="extract" nodegroup="channel">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="index" type="integer" value="0" uimin="0" uimax="3" uniform="true" />
+    <output name="out" type="float" default="0.0" />
+  </nodedef>
+  <nodedef name="ND_extract_vector2" node="extract" nodegroup="channel">
+    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="index" type="integer" value="0" uimin="0" uimax="1" uniform="true" />
+    <output name="out" type="float" default="0.0" />
+  </nodedef>
+  <nodedef name="ND_extract_vector3" node="extract" nodegroup="channel">
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="index" type="integer" value="0" uimin="0" uimax="2" uniform="true" />
+    <output name="out" type="float" default="0.0" />
+  </nodedef>
+  <nodedef name="ND_extract_vector4" node="extract" nodegroup="channel">
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="index" type="integer" value="0" uimin="0" uimax="3" uniform="true" />
+    <output name="out" type="float" default="0.0" />
+  </nodedef>
+
 
   <!--
     Node: <separate2>, <separate3>, <separate4> Supplemental Nodes

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -11,23 +11,23 @@
   <!-- Data types                                                               -->
   <!-- ======================================================================== -->
 
-  <typedef name="boolean" />
+  <typedef name="boolean" zero="false" one="true"/>
   <typedef name="integer" zero="0" one="1"/>
-  <typedef name="float" zero="0.0" one="1.0"/>
-  <typedef name="color3" semantic="color" zero="0.0,0.0,0.0" one="1.0,1.0,1.0"/>
-  <typedef name="color4" semantic="color" zero="0.0,0.0,0.0,0.0" one="1.0,1.0,1.0,1.0"/>
-  <typedef name="vector2" zero="0.0,0.0" one="1.0,1.0"/>
-  <typedef name="vector3" zero="0.0,0.0,0.0" one="1.0,1.0,1.0"/>
-  <typedef name="vector4" zero="0.0,0.0,0.0,0.0" one="1.0,1.0,1.0,1.0"/>
-  <typedef name="matrix33" zero="0.0,0.0,0.0, 0.0,0.0,0.0, 0.0,0.0,0.0" identity="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
-  <typedef name="matrix44" zero="0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0" identity="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
-  <typedef name="string" />
-  <typedef name="filename" />
+  <typedef name="float" zero="0.0" one="1.0" half="0.5" />
+  <typedef name="color3" semantic="color" zero="0.0,0.0,0.0" one="1.0,1.0,1.0" half="0.5,0.5,0.5" />
+  <typedef name="color4" semantic="color" zero="0.0,0.0,0.0,0.0" one="1.0,1.0,1.0,1.0" half="0.5,0.5,0.5,0.5" />
+  <typedef name="vector2" zero="0.0,0.0" one="1.0,1.0" half="0.5,0.5,0.5" />
+  <typedef name="vector3" zero="0.0,0.0,0.0" one="1.0,1.0,1.0" half="0.5,0.5,0.5" />
+  <typedef name="vector4" zero="0.0,0.0,0.0,0.0" one="1.0,1.0,1.0,1.0" half="0.5,0.5,0.5,0.5" />
+  <typedef name="matrix33" zero="0.0,0.0,0.0, 0.0,0.0,0.0, 0.0,0.0,0.0" one="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
+  <typedef name="matrix44" zero="0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0" one="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
+  <typedef name="string" zero="" />
+  <typedef name="filename" zero="" />
   <typedef name="geomname" />
-  <typedef name="surfaceshader" semantic="shader" context="surface" />
-  <typedef name="displacementshader" semantic="shader" context="displacement" />
-  <typedef name="volumeshader" semantic="shader" context="volume" />
-  <typedef name="lightshader" semantic="shader" context="light" />
+  <typedef name="surfaceshader" semantic="shader" context="surface" zero="" />
+  <typedef name="displacementshader" semantic="shader" context="displacement" zero="" />
+  <typedef name="volumeshader" semantic="shader" context="volume" zero="" />
+  <typedef name="lightshader" semantic="shader" context="light" zero="" />
   <typedef name="material" semantic="material" />
   <typedef name="none" />
 
@@ -123,212 +123,67 @@
     Node: <image>
     Samples data from a single image, or from a layer within a multi-layer image.
   -->
-  <nodedef name="ND_image_float" node="image" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uiname="Filename" uniform="true" />
-    <input name="layer" type="string" value="" uiname="Layer" uniform="true" />
-    <input name="default" type="float" value="0.0" uiname="Default Color" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
-    <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
-    <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type" uniform="true" />
-    <input name="framerange" type="string" value="" uiname="Frame Range" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uiname="Frame Offset" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action" uniform="true" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_image_color3" node="image" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uiname="Filename" uniform="true" />
-    <input name="layer" type="string" value="" uiname="Layer" uniform="true" />
-    <input name="default" type="color3" value="0.0, 0.0, 0.0" uiname="Default Color" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
-    <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
-    <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type" uniform="true" />
-    <input name="framerange" type="string" value="" uiname="Frame Range" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uiname="Frame Offset" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action" uniform="true" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_image_color4" node="image" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uiname="Filename" uniform="true" />
-    <input name="layer" type="string" value="" uiname="Layer" uniform="true" />
-    <input name="default" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Default Color" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
-    <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
-    <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type" uniform="true" />
-    <input name="framerange" type="string" value="" uiname="Frame Range" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uiname="Frame Offset" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action" uniform="true" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_image_vector2" node="image" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uiname="Filename" uniform="true" />
-    <input name="layer" type="string" value="" uiname="Layer" uniform="true" />
-    <input name="default" type="vector2" value="0.0, 0.0" uiname="Default Color" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
-    <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
-    <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type" uniform="true" />
-    <input name="framerange" type="string" value="" uiname="Frame Range" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uiname="Frame Offset" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action" uniform="true" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_image_vector3" node="image" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uiname="Filename" uniform="true" />
-    <input name="layer" type="string" value="" uiname="Layer" uniform="true" />
-    <input name="default" type="vector3" value="0.0, 0.0, 0.0" uiname="Default Color" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
-    <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
-    <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type" uniform="true" />
-    <input name="framerange" type="string" value="" uiname="Frame Range" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uiname="Frame Offset" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action" uniform="true" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_image_vector4" node="image" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uiname="Filename" uniform="true" />
-    <input name="layer" type="string" value="" uiname="Layer" uniform="true" />
-    <input name="default" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Default Color" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
-    <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
-    <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type" uniform="true" />
-    <input name="framerange" type="string" value="" uiname="Frame Range" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uiname="Frame Offset" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action" uniform="true" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_image" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_image_@typeName@" node="image" nodegroup="texture2d">
+      <input name="file" type="filename" value="" uiname="Filename" uniform="true" />
+      <input name="layer" type="string" value="" uiname="Layer" uniform="true" />
+      <input name="default" type="@typeName@" value="Value:zero" uiname="Default Color" />
+      <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+      <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
+      <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
+      <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type" uniform="true" />
+      <input name="framerange" type="string" value="" uiname="Frame Range" uniform="true" />
+      <input name="frameoffset" type="integer" value="0" uiname="Frame Offset" uniform="true" />
+      <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action" uniform="true" />
+      <output name="out" type="float" default="Value:zero" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <tiledimage> Supplemental Node
     Samples data from a single image, with provisions for tiling and offsetting the image
     across uv space.
   -->
-  <nodedef name="ND_tiledimage_float" node="tiledimage" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uniform="true" />
-    <input name="default" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="uvtiling" type="vector2" value="1.0, 1.0" />
-    <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-    <input name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_tiledimage_color3" node="tiledimage" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uniform="true" />
-    <input name="default" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="uvtiling" type="vector2" value="1.0, 1.0" />
-    <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-    <input name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_tiledimage_color4" node="tiledimage" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uniform="true" />
-    <input name="default" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="uvtiling" type="vector2" value="1.0, 1.0" />
-    <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-    <input name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_tiledimage_vector2" node="tiledimage" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uniform="true" />
-    <input name="default" type="vector2" value="0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="uvtiling" type="vector2" value="1.0, 1.0" />
-    <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-    <input name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_tiledimage_vector3" node="tiledimage" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uniform="true" />
-    <input name="default" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="uvtiling" type="vector2" value="1.0, 1.0" />
-    <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-    <input name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_tiledimage_vector4" node="tiledimage" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uniform="true" />
-    <input name="default" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="uvtiling" type="vector2" value="1.0, 1.0" />
-    <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-    <input name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_tiledimage" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_tiledimage_@typeName@" node="tiledimage" nodegroup="texture2d">
+      <input name="file" type="filename" value="" uniform="true" />
+      <input name="default" type="@typeName@" value="Value:zero" />
+      <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+      <input name="uvtiling" type="vector2" value="1.0, 1.0" />
+      <input name="uvoffset" type="vector2" value="0.0, 0.0" />
+      <input name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance" />
+      <input name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance" />
+      <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
+      <input name="framerange" type="string" value="" uniform="true" />
+      <input name="frameoffset" type="integer" value="0" uniform="true" />
+      <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <hextiledimage> Supplemental Node
     Samples data from a single image, with provisions for hex-tiling and randomizing the image
     across uv space.
   -->
-  <nodedef name="ND_hextiledimage_color3" node="hextiledimage" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uniform="true" />
-    <input name="default" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="tiling" type="vector2" value="1.0, 1.0" />
-    <input name="rotation" type="float" value="1.0" />
-    <input name="rotationrange" type="vector2" value="0.0, 360.0" />
-    <input name="scale" type="float" value="1.0" />
-    <input name="scalerange" type="vector2" value="0.5, 2.0" />
-    <input name="offset" type="float" value="1.0" />
-    <input name="offsetrange" type="vector2" value="0.0, 1.0" />
-    <input name="falloff" type="float" value="0.5" />
-    <input name="falloffcontrast" type="float" value="0.5" />
-    <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_hextiledimage_color4" node="hextiledimage" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uniform="true" />
-    <input name="default" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="tiling" type="vector2" value="1.0, 1.0" />
-    <input name="rotation" type="float" value="1.0" />
-    <input name="rotationrange" type="vector2" value="0.0, 360.0" />
-    <input name="scale" type="float" value="1.0" />
-    <input name="scalerange" type="vector2" value="0.5, 2.0" />
-    <input name="offset" type="float" value="1.0" />
-    <input name="offsetrange" type="vector2" value="0.0, 1.0" />
-    <input name="falloff" type="float" value="0.5" />
-    <input name="falloffcontrast" type="float" value="0.5" />
-    <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_hextiledimage" varName="typeName" options="color3, color4">
+    <nodedef name="ND_hextiledimage_@typeName@" node="hextiledimage" nodegroup="texture2d">
+      <input name="file" type="filename" value="" uniform="true" />
+      <input name="default" type="@typeName@" value="Value:zero" />
+      <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+      <input name="tiling" type="vector2" value="1.0, 1.0" />
+      <input name="rotation" type="float" value="1.0" />
+      <input name="rotationrange" type="vector2" value="0.0, 360.0" />
+      <input name="scale" type="float" value="1.0" />
+      <input name="scalerange" type="vector2" value="0.5, 2.0" />
+      <input name="offset" type="float" value="1.0" />
+      <input name="offsetrange" type="vector2" value="0.0, 1.0" />
+      <input name="falloff" type="float" value="0.5" />
+      <input name="falloffcontrast" type="float" value="0.5" />
+      <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" />
+      <output name="out" type="@typeName@" default="@Value:zero" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <triplanarprojection> Supplemental Node
@@ -336,114 +191,26 @@
     representation of the images along each of the three respective coordinate axes, computing
     an adjustable weighted blend of the three samples using the geometric normal.
   -->
-  <nodedef name="ND_triplanarprojection_float" node="triplanarprojection" nodegroup="texture3d">
-    <input name="filex" type="filename" value="" uniform="true" />
-    <input name="filey" type="filename" value="" uniform="true" />
-    <input name="filez" type="filename" value="" uniform="true" />
-    <input name="layerx" type="string" value="" uniform="true" />
-    <input name="layery" type="string" value="" uniform="true" />
-    <input name="layerz" type="string" value="" uniform="true" />
-    <input name="default" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <input name="normal" type="vector3" defaultgeomprop="Nobject" />
-    <input name="upaxis" type="integer" value="2" enum="X,Y,Z" enumvalues="0,1,2" uniform="true" />
-    <input name="blend" type="float" value="1.0" uimin="0.0" uimax="1.0" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_triplanarprojection_color3" node="triplanarprojection" nodegroup="texture3d">
-    <input name="filex" type="filename" value="" uniform="true" />
-    <input name="filey" type="filename" value="" uniform="true" />
-    <input name="filez" type="filename" value="" uniform="true" />
-    <input name="layerx" type="string" value="" uniform="true" />
-    <input name="layery" type="string" value="" uniform="true" />
-    <input name="layerz" type="string" value="" uniform="true" />
-    <input name="default" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <input name="normal" type="vector3" defaultgeomprop="Nobject" />
-    <input name="upaxis" type="integer" value="2" enum="X,Y,Z" enumvalues="0,1,2" uniform="true" />
-    <input name="blend" type="float" value="1.0" uimin="0.0" uimax="1.0" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_triplanarprojection_color4" node="triplanarprojection" nodegroup="texture3d">
-    <input name="filex" type="filename" value="" uniform="true" />
-    <input name="filey" type="filename" value="" uniform="true" />
-    <input name="filez" type="filename" value="" uniform="true" />
-    <input name="layerx" type="string" value="" uniform="true" />
-    <input name="layery" type="string" value="" uniform="true" />
-    <input name="layerz" type="string" value="" uniform="true" />
-    <input name="default" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <input name="normal" type="vector3" defaultgeomprop="Nobject" />
-    <input name="upaxis" type="integer" value="2" enum="X,Y,Z" enumvalues="0,1,2" uniform="true" />
-    <input name="blend" type="float" value="1.0" uimin="0.0" uimax="1.0" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_triplanarprojection_vector2" node="triplanarprojection" nodegroup="texture3d">
-    <input name="filex" type="filename" value="" uniform="true" />
-    <input name="filey" type="filename" value="" uniform="true" />
-    <input name="filez" type="filename" value="" uniform="true" />
-    <input name="layerx" type="string" value="" uniform="true" />
-    <input name="layery" type="string" value="" uniform="true" />
-    <input name="layerz" type="string" value="" uniform="true" />
-    <input name="default" type="vector2" value="0.0, 0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <input name="normal" type="vector3" defaultgeomprop="Nobject" />
-    <input name="upaxis" type="integer" value="2" enum="X,Y,Z" enumvalues="0,1,2" uniform="true" />
-    <input name="blend" type="float" value="1.0" uimin="0.0" uimax="1.0" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_triplanarprojection_vector3" node="triplanarprojection" nodegroup="texture3d">
-    <input name="filex" type="filename" value="" uniform="true" />
-    <input name="filey" type="filename" value="" uniform="true" />
-    <input name="filez" type="filename" value="" uniform="true" />
-    <input name="layerx" type="string" value="" uniform="true" />
-    <input name="layery" type="string" value="" uniform="true" />
-    <input name="layerz" type="string" value="" uniform="true" />
-    <input name="default" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <input name="normal" type="vector3" defaultgeomprop="Nobject" />
-    <input name="upaxis" type="integer" value="2" enum="X,Y,Z" enumvalues="0,1,2" uniform="true" />
-    <input name="blend" type="float" value="1.0" uimin="0.0" uimax="1.0" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_triplanarprojection_vector4" node="triplanarprojection" nodegroup="texture3d">
-    <input name="filex" type="filename" value="" uniform="true" />
-    <input name="filey" type="filename" value="" uniform="true" />
-    <input name="filez" type="filename" value="" uniform="true" />
-    <input name="layerx" type="string" value="" uniform="true" />
-    <input name="layery" type="string" value="" uniform="true" />
-    <input name="layerz" type="string" value="" uniform="true" />
-    <input name="default" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <input name="normal" type="vector3" defaultgeomprop="Nobject" />
-    <input name="upaxis" type="integer" value="2" enum="X,Y,Z" enumvalues="0,1,2" uniform="true" />
-    <input name="blend" type="float" value="1.0" uimin="0.0" uimax="1.0" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_triplanarprojection" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_triplanarprojection_@typeName@" node="triplanarprojection" nodegroup="texture3d">
+      <input name="filex" type="filename" value="" uniform="true" />
+      <input name="filey" type="filename" value="" uniform="true" />
+      <input name="filez" type="filename" value="" uniform="true" />
+      <input name="layerx" type="string" value="" uniform="true" />
+      <input name="layery" type="string" value="" uniform="true" />
+      <input name="layerz" type="string" value="" uniform="true" />
+      <input name="default" type="@typeName@" value="Value:zero" />
+      <input name="position" type="vector3" defaultgeomprop="Pobject" />
+      <input name="normal" type="vector3" defaultgeomprop="Nobject" />
+      <input name="upaxis" type="integer" value="2" enum="X,Y,Z" enumvalues="0,1,2" uniform="true" />
+      <input name="blend" type="float" value="1.0" uimin="0.0" uimax="1.0" />
+      <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
+      <input name="framerange" type="string" value="" uniform="true" />
+      <input name="frameoffset" type="integer" value="0" uniform="true" />
+      <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
   <!-- ======================================================================== -->
   <!-- Procedural nodes                                                         -->
@@ -454,54 +221,19 @@
     A constant value. When exposed as a public parameter, this is a way to create a
     value that can be accessed in multiple places in the opgraph.
   -->
-  <nodedef name="ND_constant_float" node="constant" nodegroup="procedural">
-    <input name="value" type="float" value="0.0" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_constant_color3" node="constant" nodegroup="procedural">
-    <input name="value" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_constant_color4" node="constant" nodegroup="procedural">
-    <input name="value" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_constant_vector2" node="constant" nodegroup="procedural">
-    <input name="value" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_constant_vector3" node="constant" nodegroup="procedural">
-    <input name="value" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_constant_vector4" node="constant" nodegroup="procedural">
-    <input name="value" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_constant_boolean" node="constant" nodegroup="procedural">
-    <input name="value" type="boolean" value="false" />
-    <output name="out" type="boolean" default="false" />
-  </nodedef>
-  <nodedef name="ND_constant_integer" node="constant" nodegroup="procedural">
-    <input name="value" type="integer" value="0" />
-    <output name="out" type="integer" default="0" />
-  </nodedef>
-  <nodedef name="ND_constant_matrix33" node="constant" nodegroup="procedural">
-    <input name="value" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <output name="out" type="matrix33" default="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-  </nodedef>
-  <nodedef name="ND_constant_matrix44" node="constant" nodegroup="procedural">
-    <input name="value" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <output name="out" type="matrix44" default="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-  </nodedef>
-  <nodedef name="ND_constant_string" node="constant" nodegroup="procedural">
-    <input name="value" type="string" value="" uniform="true" />
-    <output name="out" type="string" default="" />
-  </nodedef>
-  <nodedef name="ND_constant_filename" node="constant" nodegroup="procedural">
-    <input name="value" type="filename" value="" uniform="true" />
-    <output name="out" type="filename" default="" />
-  </nodedef>
+  <template name="TP_ND_constant" varName="typeName" options="float, color3, color4, vector2, vector3, vector4, boolean, integer, string, filename">
+    <nodedef name="ND_constant_@typeName@" node="constant" nodegroup="procedural">
+      <input name="value" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
+
+  <template name="TP_ND_constant_matrix" varName="typeName" options="matrix33, matrix44">
+    <nodedef name="ND_constant_@typeName@" node="constant" nodegroup="procedural">
+      <input name="value" type="@typeName@" value="Value:one" />
+      <output name="out" type="@typeName@" default="Value:one" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <ramp>
@@ -556,240 +288,70 @@
     Node: <ramplr>
     A left-to-right bilinear value ramp.
   -->
-  <nodedef name="ND_ramplr_float" node="ramplr" nodegroup="procedural2d">
-    <input name="valuel" type="float" value="0.0" />
-    <input name="valuer" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_ramplr_color3" node="ramplr" nodegroup="procedural2d">
-    <input name="valuel" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="valuer" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_ramplr_color4" node="ramplr" nodegroup="procedural2d">
-    <input name="valuel" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valuer" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_ramplr_vector2" node="ramplr" nodegroup="procedural2d">
-    <input name="valuel" type="vector2" value="0.0, 0.0" />
-    <input name="valuer" type="vector2" value="0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_ramplr_vector3" node="ramplr" nodegroup="procedural2d">
-    <input name="valuel" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="valuer" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_ramplr_vector4" node="ramplr" nodegroup="procedural2d">
-    <input name="valuel" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valuer" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_ramplr" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_ramplr_@typeName@" node="ramplr" nodegroup="procedural2d">
+      <input name="valuel" type="@typeName@" value="Value:zero" />
+      <input name="valuer" type="@typeName@" value="Value:zero" />
+      <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <ramptb>
     A top-to-bottom bilinear value ramp.
   -->
-  <nodedef name="ND_ramptb_float" node="ramptb" nodegroup="procedural2d">
-    <input name="valuet" type="float" value="0.0" />
-    <input name="valueb" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_ramptb_color3" node="ramptb" nodegroup="procedural2d">
-    <input name="valuet" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="valueb" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_ramptb_color4" node="ramptb" nodegroup="procedural2d">
-    <input name="valuet" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valueb" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_ramptb_vector2" node="ramptb" nodegroup="procedural2d">
-    <input name="valuet" type="vector2" value="0.0, 0.0" />
-    <input name="valueb" type="vector2" value="0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_ramptb_vector3" node="ramptb" nodegroup="procedural2d">
-    <input name="valuet" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="valueb" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_ramptb_vector4" node="ramptb" nodegroup="procedural2d">
-    <input name="valuet" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valueb" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_ramptb" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_ramptb_@typeName@" node="ramptb" nodegroup="procedural2d">
+      <input name="valuet" type="@typeName@" value="Value:zero" />
+      <input name="valueb" type="@typeName@" value="Value:zero" />
+      <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <ramp4> Supplemental Node
     A 4-corner bilinear value ramp.
   -->
-  <nodedef name="ND_ramp4_float" node="ramp4" nodegroup="procedural2d">
-    <input name="valuetl" type="float" value="0.0" />
-    <input name="valuetr" type="float" value="0.0" />
-    <input name="valuebl" type="float" value="0.0" />
-    <input name="valuebr" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_ramp4_color3" node="ramp4" nodegroup="procedural2d">
-    <input name="valuetl" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="valuetr" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="valuebl" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="valuebr" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_ramp4_color4" node="ramp4" nodegroup="procedural2d">
-    <input name="valuetl" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valuetr" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valuebl" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valuebr" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_ramp4_vector2" node="ramp4" nodegroup="procedural2d">
-    <input name="valuetl" type="vector2" value="0.0, 0.0" />
-    <input name="valuetr" type="vector2" value="0.0, 0.0" />
-    <input name="valuebl" type="vector2" value="0.0, 0.0" />
-    <input name="valuebr" type="vector2" value="0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_ramp4_vector3" node="ramp4" nodegroup="procedural2d">
-    <input name="valuetl" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="valuetr" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="valuebl" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="valuebr" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_ramp4_vector4" node="ramp4" nodegroup="procedural2d">
-    <input name="valuetl" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valuetr" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valuebl" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valuebr" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_ramp4" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_ramp4_@typeName@" node="ramp4" nodegroup="procedural2d">
+      <input name="valuetl" type="@typeName@" value="Value:zero" />
+      <input name="valuetr" type="@typeName@" value="Value:zero" />
+      <input name="valuebl" type="@typeName@" value="Value:zero" />
+      <input name="valuebr" type="@typeName@" value="Value:zero" />
+      <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <splitlr>
     A left-right split matte, split at a specified u value.
   -->
-  <nodedef name="ND_splitlr_float" node="splitlr" nodegroup="procedural2d">
-    <input name="valuel" type="float" value="0.0" uiname="Left" />
-    <input name="valuer" type="float" value="0.0" uiname="Right" />
-    <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_splitlr_color3" node="splitlr" nodegroup="procedural2d">
-    <input name="valuel" type="color3" value="0.0, 0.0, 0.0" uiname="Left" />
-    <input name="valuer" type="color3" value="0.0, 0.0, 0.0" uiname="Right" />
-    <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_splitlr_color4" node="splitlr" nodegroup="procedural2d">
-    <input name="valuel" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Left" />
-    <input name="valuer" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Right" />
-    <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_splitlr_vector2" node="splitlr" nodegroup="procedural2d">
-    <input name="valuel" type="vector2" value="0.0, 0.0" uiname="Left" />
-    <input name="valuer" type="vector2" value="0.0, 0.0" uiname="Right" />
-    <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_splitlr_vector3" node="splitlr" nodegroup="procedural2d">
-    <input name="valuel" type="vector3" value="0.0, 0.0, 0.0" uiname="Left" />
-    <input name="valuer" type="vector3" value="0.0, 0.0, 0.0" uiname="Right" />
-    <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_splitlr_vector4" node="splitlr" nodegroup="procedural2d">
-    <input name="valuel" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Left" />
-    <input name="valuer" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Right" />
-    <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <!--
-    Node: <splittb>
-    A top-bottom split matte, split at a specified v value.
-  -->
-  <nodedef name="ND_splittb_float" node="splittb" nodegroup="procedural2d">
-    <input name="valuet" type="float" value="0.0" uiname="Top" />
-    <input name="valueb" type="float" value="0.0" uiname="Bottom" />
-    <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_splittb_color3" node="splittb" nodegroup="procedural2d">
-    <input name="valuet" type="color3" value="0.0, 0.0, 0.0" uiname="Top" />
-    <input name="valueb" type="color3" value="0.0, 0.0, 0.0" uiname="Bottom" />
-    <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_splittb_color4" node="splittb" nodegroup="procedural2d">
-    <input name="valuet" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Top" />
-    <input name="valueb" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Bottom" />
-    <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_splittb_vector2" node="splittb" nodegroup="procedural2d">
-    <input name="valuet" type="vector2" value="0.0, 0.0" uiname="Top" />
-    <input name="valueb" type="vector2" value="0.0, 0.0" uiname="Bottom" />
-    <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_splittb_vector3" node="splittb" nodegroup="procedural2d">
-    <input name="valuet" type="vector3" value="0.0, 0.0, 0.0" uiname="Top" />
-    <input name="valueb" type="vector3" value="0.0, 0.0, 0.0" uiname="Bottom" />
-    <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_splittb_vector4" node="splittb" nodegroup="procedural2d">
-    <input name="valuet" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Top" />
-    <input name="valueb" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Bottom" />
-    <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_splitlr" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_splitlr_@typeName@" node="splitlr" nodegroup="procedural2d">
+      <input name="valuel" type="@typeName@" value="Value:zero" uiname="Left" />
+      <input name="valuer" type="@typeName@" value="Value:zero" uiname="Right" />
+      <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
+      <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <noise2d>
     2D Perlin noise in 1, 2, 3 or 4 channels.
   -->
-  <nodedef name="ND_noise2d_float" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
+  <template name="TP_ND_noise2d" varName="typeName" options="float, vector2, vector3, vector4">
+    <nodedef name="ND_noise2d_@typeName@" node="noise2d" nodegroup="procedural2d">
+      <input name="amplitude" type="@typeName@" value="Value:one" />
+      <input name="pivot" type="float" value="0.0" />
+      <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
+
   <nodedef name="ND_noise2d_color3" node="noise2d" nodegroup="procedural2d">
     <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" />
     <input name="pivot" type="float" value="0.0" />
@@ -802,65 +364,30 @@
     <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
-  <nodedef name="ND_noise2d_vector2" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="vector2" value="1.0, 1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_noise2d_vector3" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_noise2d_vector4" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_noise2d_color3FA" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_noise2d_color4FA" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_noise2d_vector2FA" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_noise2d_vector3FA" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_noise2d_vector4FA" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
+
+  <template name="TP_ND_noise2d_FA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_noise2d_@typeName@FA" node="noise2d" nodegroup="procedural2d">
+      <input name="amplitude" type="float" value="1.0" />
+      <input name="pivot" type="float" value="0.0" />
+      <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
+
 
   <!--
     Node: <noise3d>
     3D Perlin noise in 1, 2, 3 or 4 channels.
   -->
-  <nodedef name="ND_noise3d_float" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
+  <template name="TP_ND_noise3d" varName="typeName" options="float, vector2, vector3, vector4">
+    <nodedef name="ND_noise3d_@typeName@" node="noise3d" nodegroup="procedural3d">
+      <input name="amplitude" type="@typeName@" value="Value:one" />
+      <input name="pivot" type="float" value="0.0" />
+      <input name="position" type="vector3" defaultgeomprop="Pobject" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
+
   <nodedef name="ND_noise3d_color3" node="noise3d" nodegroup="procedural3d">
     <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" />
     <input name="pivot" type="float" value="0.0" />
@@ -873,67 +400,32 @@
     <input name="position" type="vector3" defaultgeomprop="Pobject" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
-  <nodedef name="ND_noise3d_vector2" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="vector2" value="1.0, 1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_noise3d_vector3" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_noise3d_vector4" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_noise3d_color3FA" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_noise3d_color4FA" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_noise3d_vector2FA" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_noise3d_vector3FA" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_noise3d_vector4FA" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
+
+  <template name="TP_ND_noise3d_FA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_noise3d_@typeName@FA" node="noise3d" nodegroup="procedural3d">
+      <input name="amplitude" type="float" value="1.0" />
+      <input name="pivot" type="float" value="0.0" />
+      <input name="position" type="vector3" defaultgeomprop="Pobject" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
+
 
   <!--
     Node: <fractal3d>
     3D Fractal noise in 1, 2, 3 or 4 channels.
   -->
-  <nodedef name="ND_fractal3d_float" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
+  <template name="TP_ND_fractal3d" varName="typeName" options="float, vector2, vector3, vector4">
+    <nodedef name="ND_fractal3d_@typeName@" node="fractal3d" nodegroup="procedural3d">
+      <input name="amplitude" type="@typeName@" value="Value:one" />
+      <input name="octaves" type="integer" value="3" />
+      <input name="lacunarity" type="float" value="2.0" />
+      <input name="diminish" type="float" value="0.5" />
+      <input name="position" type="vector3" defaultgeomprop="Pobject" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
+
   <nodedef name="ND_fractal3d_color3" node="fractal3d" nodegroup="procedural3d">
     <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" />
     <input name="octaves" type="integer" value="3" />
@@ -950,70 +442,17 @@
     <input name="position" type="vector3" defaultgeomprop="Pobject" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
-  <nodedef name="ND_fractal3d_vector2" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="vector2" value="1.0, 1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_fractal3d_vector3" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_fractal3d_vector4" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_fractal3d_color3FA" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_fractal3d_color4FA" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_fractal3d_vector2FA" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_fractal3d_vector3FA" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_fractal3d_vector4FA" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
+
+  <template name="TP_ND_fractal3d_FA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_fractal3d_@typeName@FA" node="fractal3d" nodegroup="procedural3d">
+      <input name="amplitude" type="float" value="1.0" />
+      <input name="octaves" type="integer" value="3" />
+      <input name="lacunarity" type="float" value="2.0" />
+      <input name="diminish" type="float" value="0.5" />
+      <input name="position" type="vector3" defaultgeomprop="Pobject" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <cellnoise2d>
@@ -1060,24 +499,14 @@
     Node: <worleynoise3d>
     3D Worley (voronoi) noise in 1, 2 or 3 channels.
   -->
-  <nodedef name="ND_worleynoise3d_float" node="worleynoise3d" nodegroup="procedural3d">
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <input name="jitter" type="float" value="1.0" />
-    <input name="style" uiname="Cell Style" type="integer" value="0" enum="Distance,Solid" enumvalues="0,1" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_worleynoise3d_vector2" node="worleynoise3d" nodegroup="procedural3d">
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <input name="jitter" type="float" value="1.0" />
-    <input name="style" uiname="Cell Style" type="integer" value="0" enum="Distance,Solid" enumvalues="0,1" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_worleynoise3d_vector3" node="worleynoise3d" nodegroup="procedural3d">
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <input name="jitter" type="float" value="1.0" />
-    <input name="style" uiname="Cell Style" type="integer" value="0" enum="Distance,Solid" enumvalues="0,1" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_worleynoise3d" varName="typeName" options="float, vector2, vector3">
+    <nodedef name="ND_worleynoise3d_@typeName@" node="worleynoise3d" nodegroup="procedural3d">
+      <input name="position" type="vector3" defaultgeomprop="Pobject" />
+      <input name="jitter" type="float" value="1.0" />
+      <input name="style" uiname="Cell Style" type="integer" value="0" enum="Distance,Solid" enumvalues="0,1" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <unifiednoise2d>
@@ -1136,47 +565,33 @@
     Node: <randomfloat>
     Produces a randomized float, based on an 'input' signal and 'seed' value.
   -->
-  <nodedef name="ND_randomfloat_float" node="randomfloat" nodegroup="procedural">
-    <input name="in" type="float" uiname="Input" value="0.0" doc="Initial randomization seed." />
-    <input name="min" type="float" uiname="Minimum" value="0.0" doc="The minimum output value." />
-    <input name="max" type="float" uiname="Maximum" value="1.0" doc="The maximum output value." />
-    <input name="seed" type="integer" uiname="Seed" value="0" doc="Additional seed." />
-    <output name="out" type="float" />
-  </nodedef>
-  <nodedef name="ND_randomfloat_integer" node="randomfloat" nodegroup="procedural">
-    <input name="in" type="integer" uiname="Input" value="0" />
-    <input name="min" type="float" uiname="Minimum" value="0.0" />
-    <input name="max" type="float" uiname="Maximum" value="1.0" />
-    <input name="seed" type="integer" uiname="Seed" value="0" />
-    <output name="out" type="float" />
-  </nodedef>
+  <template name="TP_ND_randomfloat" varName="typeName" options="float, integer">
+    <nodedef name="ND_randomfloat_@typeName@" node="randomfloat" nodegroup="procedural">
+      <input name="in" type="@typeName@" uiname="Input" value="Value:zero" doc="Initial randomization seed." />
+      <input name="min" type="float" uiname="Minimum" value="0.0" doc="The minimum output value." />
+      <input name="max" type="float" uiname="Maximum" value="1.0" doc="The maximum output value." />
+      <input name="seed" type="integer" uiname="Seed" value="0" doc="Additional seed." />
+      <output name="out" type="float" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <randomcolor>
     Produces a randomized RGB color, based on an 'input' signal and 'seed' value.
   -->
-  <nodedef name="ND_randomcolor_float" node="randomcolor" nodegroup="procedural3d">
-    <input name="in" type="float" uiname="Input" uisoftmin="0.0" uisoftmax="10.0" value="0.0" />
-    <input name="huelow" type="float" uiname="Hue Low" uisoftmin="0.0" uisoftmax="1.0" value="0" />
-    <input name="huehigh" type="float" uiname="Hue High" uisoftmin="0.0" uisoftmax="1.0" value="1" />
-    <input name="saturationlow" type="float" uiname="Saturation Low" uisoftmin="0.0" uisoftmax="1.0" value="0.825" />
-    <input name="saturationhigh" type="float" uiname="Saturation High" uisoftmin="0.0" uisoftmax="1.0" value="1" />
-    <input name="brightnesslow" type="float" uiname="Brightness Low" uisoftmin="0.0" uisoftmax="1.0" value="1" />
-    <input name="brightnesshigh" type="float" uiname="Brightness High" uisoftmin="0.0" uisoftmax="1.0" value="1" />
-    <input name="seed" type="integer" uiname="Seed" value="0" />
-    <output name="out" type="color3" />
-  </nodedef>
-  <nodedef name="ND_randomcolor_integer" node="randomcolor" nodegroup="procedural3d">
-    <input name="in" type="integer" uiname="Input" uisoftmin="0" uisoftmax="10" value="0" />
-    <input name="huelow" type="float" uiname="Hue Low" uisoftmin="0.0" uisoftmax="1.0" value="0" />
-    <input name="huehigh" type="float" uiname="Hue High" uisoftmin="0.0" uisoftmax="1.0" value="1" />
-    <input name="saturationlow" type="float" uiname="Saturation Low" uisoftmin="0.0" uisoftmax="1.0" value="0.825" />
-    <input name="saturationhigh" type="float" uiname="Saturation High" uisoftmin="0.0" uisoftmax="1.0" value="1" />
-    <input name="brightnesslow" type="float" uiname="Brightness Low" uisoftmin="0.0" uisoftmax="1.0" value="1" />
-    <input name="brightnesshigh" type="float" uiname="Brightness High" uisoftmin="0.0" uisoftmax="1.0" value="1" />
-    <input name="seed" type="integer" uiname="Seed" value="0" />
-    <output name="out" type="color3" />
-  </nodedef>
+  <template name="TP_ND_randomcolor" varName="typeName" options="float, integer">
+    <nodedef name="ND_randomcolor_@typeName@" node="randomcolor" nodegroup="procedural3d">
+      <input name="in" type="@typeName@" uiname="Input" uisoftmin="Value:zero" uisoftmax="10" value="Value:zero" />
+      <input name="huelow" type="float" uiname="Hue Low" uisoftmin="0.0" uisoftmax="1.0" value="0" />
+      <input name="huehigh" type="float" uiname="Hue High" uisoftmin="0.0" uisoftmax="1.0" value="1" />
+      <input name="saturationlow" type="float" uiname="Saturation Low" uisoftmin="0.0" uisoftmax="1.0" value="0.825" />
+      <input name="saturationhigh" type="float" uiname="Saturation High" uisoftmin="0.0" uisoftmax="1.0" value="1" />
+      <input name="brightnesslow" type="float" uiname="Brightness Low" uisoftmin="0.0" uisoftmax="1.0" value="1" />
+      <input name="brightnesshigh" type="float" uiname="Brightness High" uisoftmin="0.0" uisoftmax="1.0" value="1" />
+      <input name="seed" type="integer" uiname="Seed" value="0" />
+      <output name="out" type="color3" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <checkerboard>
@@ -1360,92 +775,48 @@
     Node: <texcoord>
     The full 2D or 3D texture coordinates associated with the currently processed data.
   -->
-  <nodedef name="ND_texcoord_vector2" node="texcoord" nodegroup="geometric">
-    <input name="index" type="integer" value="0" uniform="true" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_texcoord_vector3" node="texcoord" nodegroup="geometric">
-    <input name="index" type="integer" value="0" uniform="true" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_texcoord" varName="typeName" options="vector2, vector3">
+    <nodedef name="ND_texcoord_@typeName@" node="texcoord" nodegroup="geometric">
+      <input name="index" type="integer" value="0" uniform="true" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <geomcolor>
     The color associated with the current geometry at the current position, generally
     bound via per-vertex color values.
   -->
-  <nodedef name="ND_geomcolor_float" node="geomcolor" nodegroup="geometric">
-    <input name="index" type="integer" value="0" uniform="true" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_geomcolor_color3" node="geomcolor" nodegroup="geometric">
-    <input name="index" type="integer" value="0" uniform="true" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_geomcolor_color4" node="geomcolor" nodegroup="geometric">
-    <input name="index" type="integer" value="0" uniform="true" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_geomcolor" varName="typeName" options="float, color3, color4">
+    <nodedef name="ND_geomcolor_@typeName@" node="geomcolor" nodegroup="geometric">
+      <input name="index" type="integer" value="0" uniform="true" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <geompropvalue>
     The value of the specified geometric property for the current geometry.
   -->
-  <nodedef name="ND_geompropvalue_integer" node="geompropvalue" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="integer" value="0" />
-    <output name="out" type="integer" default="0" />
-  </nodedef>
-  <nodedef name="ND_geompropvalue_boolean" node="geompropvalue" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="boolean" value="false" />
-    <output name="out" type="boolean" default="false" />
-  </nodedef>
-  <nodedef name="ND_geompropvalue_float" node="geompropvalue" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="float" value="0.0" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_geompropvalue_color3" node="geompropvalue" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_geompropvalue_color4" node="geompropvalue" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_geompropvalue_vector2" node="geompropvalue" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_geompropvalue_vector3" node="geompropvalue" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_geompropvalue_vector4" node="geompropvalue" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_geompropvalue" varName="typeName" options="integer, boolean, float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_geompropvalue_@typeName@" node="geompropvalue" nodegroup="geometric">
+      <input name="geomprop" type="string" value="" uniform="true" />
+      <input name="default" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <geompropvalueuniform>
     The uniform, non-varying value of the specified geometric property for the current geometry.
   -->
-  <nodedef name="ND_geompropvalueuniform_string" node="geompropvalueuniform" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="string" value="" uniform="true" />
-    <output name="out" type="string" default="" uniform="true" />
-  </nodedef>
-  <nodedef name="ND_geompropvalueuniform_filename" node="geompropvalueuniform" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="filename" value="" uniform="true" />
-    <output name="out" type="filename" default="" uniform="true" />
-  </nodedef>
+  <template name="TP_ND_geompropvalueuniform" varName="typeName" options="string, filename">
+    <nodedef name="ND_geompropvalueuniform_@typeName@" node="geompropvalueuniform" nodegroup="geometric">
+      <input name="geomprop" type="string" value="" uniform="true" />
+      <input name="default" type="@typeName@" value="Value:zero" uniform="true" />
+      <output name="out" type="@typeName@" default="Value:zero" uniform="true" />
+    </nodedef>
+  </template>
 
 
   <!--
@@ -1500,7 +871,7 @@
   </template>
   <template name="TP_ND_add_matrix" varName="typeName" options="matrix33, matrix44">
     <nodedef name="ND_add_@typeName@" node="add" nodegroup="math">
-      <input name="in1" type="@typeName@" value="Value:identity" />
+      <input name="in1" type="@typeName@" value="Value:one" />
       <input name="in2" type="@typeName@" value="Value:zero" />
       <output name="out" type="@typeName@" defaultinput="in1" />
     </nodedef>
@@ -1514,7 +885,7 @@
   </template>
   <template name="TP_ND_add_matrixFA" varName="typeName" options="matrix33, matrix44">
     <nodedef name="ND_add_@typeName@FA" node="add" nodegroup="math">
-      <input name="in1" type="@typeName@" value="Value:identity" />
+      <input name="in1" type="@typeName@" value="Value:one" />
       <input name="in2" type="float" value="Value:zero" />
       <output name="out" type="@typeName@" defaultinput="in1" />
     </nodedef>
@@ -1533,7 +904,7 @@
   </template>
   <template name="TP_ND_subtract_matrix" varName="typeName" options="matrix33, matrix44">
     <nodedef name="ND_subtract_@typeName@" node="subtract" nodegroup="math">
-      <input name="in1" type="@typeName@" value="Value:identity" />
+      <input name="in1" type="@typeName@" value="Value:one" />
       <input name="in2" type="@typeName@" value="Value:zero" />
       <output name="out" type="@typeName@" defaultinput="in1" />
     </nodedef>
@@ -1547,7 +918,7 @@
   </template>
   <template name="TP_ND_subtract_matrixFA" varName="typeName" options="matrix33, matrix44">
     <nodedef name="ND_subtract_@typeName@FA" node="subtract" nodegroup="math">
-      <input name="in1" type="@typeName@" value="Value:identity" />
+      <input name="in1" type="@typeName@" value="Value:one" />
       <input name="in2" type="float" value="Value:zero" />
       <output name="out" type="@typeName@" defaultinput="in1" />
     </nodedef>
@@ -1567,8 +938,8 @@
   </template>
   <template name="TP_ND_multiply_matrix" varName="typeName" options="matrix33, matrix44">
     <nodedef name="ND_multiply_@typeName@" node="multiply" nodegroup="math">
-      <input name="in1" type="@typeName@" value="Value:identity" />
-      <input name="in2" type="@typeName@" value="Value:identity" />
+      <input name="in1" type="@typeName@" value="Value:one" />
+      <input name="in2" type="@typeName@" value="Value:one" />
       <output name="out" type="@typeName@" defaultinput="in1" />
     </nodedef>
   </template>
@@ -1595,8 +966,8 @@
   </template>
   <template name="TP_ND_divide_matrix" varName="typeName" options="matrix33, matrix44">
     <nodedef name="ND_divide_@typeName@" node="divide" nodegroup="math">
-      <input name="in1" type="@typeName@" value="Value:identity" />
-      <input name="in2" type="@typeName@" value="Value:identity" />
+      <input name="in1" type="@typeName@" value="Value:one" />
+      <input name="in2" type="@typeName@" value="Value:one" />
       <output name="out" type="@typeName@" defaultinput="in1" />
     </nodedef>
   </template>
@@ -1613,209 +984,73 @@
     The remaining fraction after dividing one float/color/vector by another and
     subtracting the integer portion. The modula "in2" value cannot be 0.
   -->
-  <nodedef name="ND_modulo_float" node="modulo" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="float" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_modulo_color3" node="modulo" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="1.0, 1.0, 1.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_modulo_color4" node="modulo" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_modulo_vector2" node="modulo" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="1.0, 1.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_modulo_vector3" node="modulo" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_modulo_vector4" node="modulo" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_modulo_color3FA" node="modulo" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_modulo_color4FA" node="modulo" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_modulo_vector2FA" node="modulo" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_modulo_vector3FA" node="modulo" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_modulo_vector4FA" node="modulo" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
+  <template name="TP_ND_modulo" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_modulo_@typeName@" node="modulo" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:one" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+  <template name="TP_ND_moduloFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_modulo_@typeName@FA" node="modulo" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="float" value="1.0" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <fract>
     The fraction of a float or vector.
   -->
-  <nodedef name="ND_fract_float" node="fract" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_fract_color3" node="fract" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_fract_color4" node="fract" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_fract_vector2" node="fract" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_fract_vector3" node="fract" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_fract_vector4" node="fract" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_modulo" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_fract_@typeName@" node="fract" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <invert>
     Subtract the incoming float/color/vector from "amount" in all channels,
     outputting: amount - in.
   -->
-  <nodedef name="ND_invert_float" node="invert" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_invert_color3" node="invert" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="color3" value="1.0, 1.0, 1.0" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_invert_color4" node="invert" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_invert_vector2" node="invert" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="amount" type="vector2" value="1.0, 1.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_invert_vector3" node="invert" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="vector3" value="1.0, 1.0, 1.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_invert_vector4" node="invert" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_invert_color3FA" node="invert" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_invert_color4FA" node="invert" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_invert_vector2FA" node="invert" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_invert_vector3FA" node="invert" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_invert_vector4FA" node="invert" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_invert" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_invert_@typeName@" node="invert" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:one" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+  <template name="TP_ND_invertFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_invert_@typeName@FA" node="invert" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="float" value="1.0" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <absval>
     The per-channel absolute value of the incoming float/color/vector.
   -->
-  <nodedef name="ND_absval_float" node="absval" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_absval_color3" node="absval" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_absval_color4" node="absval" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_absval_vector2" node="absval" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_absval_vector3" node="absval" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_absval_vector4" node="absval" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_absval" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_absval_@typeName@" node="absval" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <floor>
     Find the nearest integer less than or equal to the parameter.
   -->
-  <nodedef name="ND_floor_float" node="floor" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_floor_color3" node="floor" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_floor_color4" node="floor" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_floor_vector2" node="floor" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_floor_vector3" node="floor" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_floor_vector4" node="floor" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_floor" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_floor_@typeName@" node="floor" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
   <nodedef name="ND_floor_integer" node="floor" nodegroup="math">
     <input name="in" type="float" value="0.0" />
     <output name="out" type="integer" defaultinput="in" />
@@ -1825,30 +1060,12 @@
     Node: <ceil>
     Find the nearest integer greater than or equal to the parameter.
   -->
-  <nodedef name="ND_ceil_float" node="ceil" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_ceil_color3" node="ceil" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_ceil_color4" node="ceil" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_ceil_vector2" node="ceil" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_ceil_vector3" node="ceil" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_ceil_vector4" node="ceil" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_ceil" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_ceil_@typeName@" node="ceil" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
   <nodedef name="ND_ceil_integer" node="ceil" nodegroup="math">
     <input name="in" type="float" value="0.0" />
     <output name="out" type="integer" defaultinput="in" />
@@ -1858,30 +1075,12 @@
     Node: <round>
     Round incoming float/color/vector values.
   -->
-  <nodedef name="ND_round_float" node="round" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_round_color3" node="round" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_round_color4" node="round" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_round_vector2" node="round" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_round_vector3" node="round" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_round_vector4" node="round" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_round" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_round_@typeName@" node="round" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
   <nodedef name="ND_round_integer" node="round" nodegroup="math">
     <input name="in" type="float" value="0.0" />
     <output name="out" type="integer" defaultinput="in" />
@@ -1891,574 +1090,229 @@
     Node: <power>
     Raise incoming float/color/vector values to the "in2" power.
   -->
-  <nodedef name="ND_power_float" node="power" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="float" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_power_color3" node="power" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="1.0, 1.0, 1.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_power_color4" node="power" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_power_vector2" node="power" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="1.0, 1.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_power_vector3" node="power" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_power_vector4" node="power" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_power_color3FA" node="power" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_power_color4FA" node="power" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_power_vector2FA" node="power" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_power_vector3FA" node="power" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_power_vector4FA" node="power" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
+  <template name="TP_ND_power" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_power_@typeName@" node="power" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:one" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+  <template name="TP_ND_powerFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_power_@typeName@FA" node="power" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="float" value="1.0" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <safepower>
     Raise incoming float/color/vector values to the "in2" power.
     Negative "in1" values will result in negative output values. ie. out = sign(in1)*pow(abs(in1),in2)
   -->
-  <nodedef name="ND_safepower_float" node="safepower" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="float" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_safepower_color3" node="safepower" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="1.0, 1.0, 1.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_safepower_color4" node="safepower" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_safepower_vector2" node="safepower" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="1.0, 1.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_safepower_vector3" node="safepower" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_safepower_vector4" node="safepower" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_safepower_color3FA" node="safepower" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_safepower_color4FA" node="safepower" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_safepower_vector2FA" node="safepower" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_safepower_vector3FA" node="safepower" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_safepower_vector4FA" node="safepower" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
+  <template name="TP_ND_safepower" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_safepower_@typeName@" node="safepower" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:one" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+  <template name="TP_ND_safepowerFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_safepower_@typeName@FA" node="safepower" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="float" value="1.0" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
 
   <!--
     Nodes: <sin>, <cos>, <tan>, <asin>, <acos>, <atan2>
     Standard trigonometric functions; angles are given in radians.
   -->
-  <nodedef name="ND_sin_float" node="sin" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_cos_float" node="cos" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_tan_float" node="tan" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_asin_float" node="asin" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_acos_float" node="acos" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_atan2_float" node="atan2" nodegroup="math">
-    <input name="iny" type="float" value="0.0" />
-    <input name="inx" type="float" value="1.0" />
-    <output name="out" type="float" defaultinput="iny" />
-  </nodedef>
-  <nodedef name="ND_sin_vector2" node="sin" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_cos_vector2" node="cos" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_tan_vector2" node="tan" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_asin_vector2" node="asin" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_acos_vector2" node="acos" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_atan2_vector2" node="atan2" nodegroup="math">
-    <input name="iny" type="vector2" value="1.0, 1.0" />
-    <input name="inx" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="iny" />
-  </nodedef>
-  <nodedef name="ND_sin_vector3" node="sin" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_cos_vector3" node="cos" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_tan_vector3" node="tan" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_asin_vector3" node="asin" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_acos_vector3" node="acos" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_atan2_vector3" node="atan2" nodegroup="math">
-    <input name="iny" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="inx" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="iny" />
-  </nodedef>
-  <nodedef name="ND_sin_vector4" node="sin" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_cos_vector4" node="cos" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_tan_vector4" node="tan" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_asin_vector4" node="asin" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_acos_vector4" node="acos" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_atan2_vector4" node="atan2" nodegroup="math">
-    <input name="iny" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="inx" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="iny" />
-  </nodedef>
+  <template name="TP_ND_sin" varName="typeName" options="float, vector2, vector3, vector4">
+    <nodedef name="ND_sin_@typeName@" node="sin" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
+
+  <template name="TP_ND_cos" varName="typeName" options="float, vector2, vector3, vector4">
+    <nodedef name="ND_cos_@typeName@" node="cos" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
+
+  <template name="TP_ND_tan" varName="typeName" options="float, vector2, vector3, vector4">
+    <nodedef name="ND_tan_@typeName@" node="tan" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
+
+  <template name="TP_ND_asin" varName="typeName" options="float, vector2, vector3, vector4">
+    <nodedef name="ND_asin_@typeName@" node="asin" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
+
+  <template name="TP_ND_acos" varName="typeName" options="float, vector2, vector3, vector4">
+    <nodedef name="ND_acos_@typeName@" node="acos" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
+
+  <template name="TP_ND_atan2" varName="typeName" options="float, vector2, vector3, vector4">
+    <nodedef name="ND_atan2_@typeName@" node="atan2" nodegroup="math">
+      <input name="iny" type="@typeName@" value="Value:zero" />
+      <input name="inx" type="@typeName@" value="Value:one" />
+      <output name="out" type="@typeName@" defaultinput="iny" />
+    </nodedef>
+  </template>
 
   <!--
     Nodes: <sqrt>, <ln>, <exp>
     Standard math functions.
   -->
-  <nodedef name="ND_sqrt_float" node="sqrt" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_ln_float" node="ln" nodegroup="math">
-    <input name="in" type="float" value="1.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_exp_float" node="exp" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_sqrt_vector2" node="sqrt" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_ln_vector2" node="ln" nodegroup="math">
-    <input name="in" type="vector2" value="1.0, 1.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_exp_vector2" node="exp" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_sqrt_vector3" node="sqrt" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_ln_vector3" node="ln" nodegroup="math">
-    <input name="in" type="vector3" value="1.0, 1.0, 1.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_exp_vector3" node="exp" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_sqrt_vector4" node="sqrt" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_ln_vector4" node="ln" nodegroup="math">
-    <input name="in" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_exp_vector4" node="exp" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_sqrt" varName="typeName" options="float, vector2, vector3, vector4">
+    <nodedef name="ND_sqrt_@typeName@" node="sqrt" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
+
+  <template name="TP_ND_ln" varName="typeName" options="float, vector2, vector3, vector4">
+    <nodedef name="ND_ln_@typeName@" node="ln" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:one" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
+
+  <template name="TP_ND_exp" varName="typeName" options="float, vector2, vector3, vector4">
+    <nodedef name="ND_exp_@typeName@" node="exp" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <sign>
     Sign of eachinput channel: -1, 0 or +1
   -->
-  <nodedef name="ND_sign_float" node="sign" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_sign_color3" node="sign" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_sign_color4" node="sign" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_sign_vector2" node="sign" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_sign_vector3" node="sign" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_sign_vector4" node="sign" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_sign" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_sign_@typeName@" node="sign" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <clamp>
     Clamp incoming value to a specified range of values.
   -->
-  <nodedef name="ND_clamp_float" node="clamp" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_clamp_color3" node="clamp" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="low" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="high" type="color3" value="1.0, 1.0, 1.0" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_clamp_color4" node="clamp" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="low" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="high" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_clamp_vector2" node="clamp" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="low" type="vector2" value="0.0, 0.0" />
-    <input name="high" type="vector2" value="1.0, 1.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_clamp_vector3" node="clamp" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="low" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="high" type="vector3" value="1.0, 1.0, 1.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_clamp_vector4" node="clamp" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="low" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="high" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_clamp_color3FA" node="clamp" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_clamp_color4FA" node="clamp" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_clamp_vector2FA" node="clamp" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_clamp_vector3FA" node="clamp" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_clamp_vector4FA" node="clamp" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_clamp" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_clamp_@typeName@" node="clamp" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="low" type="@typeName@" value="Value:zero" />
+      <input name="high" type="@typeName@" value="Value:one" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
+
+  <template name="TP_ND_clampFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_clamp_@typeName@FA" node="clamp" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <min>
     Select the minimum among incoming values.
   -->
-  <nodedef name="ND_min_float" node="min" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_min_color3" node="min" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_min_color4" node="min" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_min_vector2" node="min" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_min_vector3" node="min" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_min_vector4" node="min" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_min_color3FA" node="min" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_min_color4FA" node="min" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_min_vector2FA" node="min" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_min_vector3FA" node="min" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_min_vector4FA" node="min" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
+  <template name="TP_ND_min" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_min_@typeName@" node="min" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+  <template name="TP_ND_minFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_min_@typeName@FA" node="min" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="float" value="0.0" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <max>
     Select the maximum among incoming values.
   -->
-  <nodedef name="ND_max_float" node="max" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_max_color3" node="max" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_max_color4" node="max" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_max_vector2" node="max" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_max_vector3" node="max" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_max_vector4" node="max" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_max_color3FA" node="max" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_max_color4FA" node="max" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_max_vector2FA" node="max" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_max_vector3FA" node="max" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_max_vector4FA" node="max" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
+  <template name="TP_ND_max" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_max_@typeName@" node="max" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+  <template name="TP_ND_maxFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_max_@typeName@FA" node="max" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="float" value="0.0" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <normalize>
     Outputs the normalized vector from the incoming vector stream.
   -->
-  <nodedef name="ND_normalize_vector2" node="normalize" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_normalize_vector3" node="normalize" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_normalize_vector4" node="normalize" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_normalize" varName="typeName" options="vector2, vector3, vector4">
+    <nodedef name="ND_normalize_@typeName@" node="normalize" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <magnitude>
     Outputs the float magnitude (vector length) of the incoming vector stream.
   -->
-  <nodedef name="ND_magnitude_vector2" node="magnitude" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_magnitude_vector3" node="magnitude" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_magnitude_vector4" node="magnitude" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
+  <template name="TP_ND_normalize" varName="typeName" options="vector2, vector3, vector4">
+    <nodedef name="ND_normalize_@typeName@" node="normalize" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <output name="out" type="float" defaultinput="in" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <distance>
     Measures the distance between two points in 2D, 3D, or 4D.
   -->
-  <nodedef name="ND_distance_vector2" node="distance" nodegroup="math">
-    <input name="in1" type="vector2" uiname="in1" value="0.0, 0.0" />
-    <input name="in2" type="vector2" uiname="in2" value="0.0, 0.0" />
-    <output name="out" type="float" />
-  </nodedef>
-  <nodedef name="ND_distance_vector3" node="distance" nodegroup="math">
-    <input name="in1" type="vector3" uiname="in1" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" uiname="in2" value="0.0, 0.0, 0.0" />
-    <output name="out" type="float" />
-  </nodedef>
-  <nodedef name="ND_distance_vector4" node="distance" nodegroup="math">
-    <input name="in1" type="vector4" uiname="in1" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" uiname="in2" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="float" />
-  </nodedef>
+  <template name="TP_ND_distance" varName="typeName" options="vector2, vector3, vector4">
+    <nodedef name="ND_distance_@typeName@" node="distance" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:zero" />
+      <output name="out" type="float" defaultinput="in1" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <dotproduct>
     Perform a dot product of two 2-4 channel vectors
   -->
-  <nodedef name="ND_dotproduct_vector2" node="dotproduct" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_dotproduct_vector3" node="dotproduct" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_dotproduct_vector4" node="dotproduct" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
+  <template name="TP_ND_dotproduct" varName="typeName" options="vector2, vector3, vector4">
+    <nodedef name="ND_dotproduct_@typeName@" node="dotproduct" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:zero" />
+      <output name="out" type="float" defaultinput="in1" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <crossproduct>
@@ -2577,27 +1431,23 @@
     Node: <transpose>
     Output the transpose of the incoming matrix.
   -->
-  <nodedef name="ND_transpose_matrix33" node="transpose" nodegroup="math">
-    <input name="in" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <output name="out" type="matrix33" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_transpose_matrix44" node="transpose" nodegroup="math">
-    <input name="in" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <output name="out" type="matrix44" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_transpose" varName="typeName" options="matrix33, matrix44">
+    <nodedef name="ND_transpose_@typeName@" node="transpose" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:one" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <determinant>
     Output the determinant of the incoming matrix.
   -->
-  <nodedef name="ND_determinant_matrix33" node="determinant" nodegroup="math">
-    <input name="in" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <output name="out" type="float" default="1.0" />
-  </nodedef>
-  <nodedef name="ND_determinant_matrix44" node="determinant" nodegroup="math">
-    <input name="in" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <output name="out" type="float" default="1.0" />
-  </nodedef>
+  <template name="TP_ND_determinant" varName="typeName" options="matrix33, matrix44">
+    <nodedef name="ND_determinant_@typeName@" node="determinant" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:one" />
+      <output name="out" type="float" default="1.0" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <invertmatrix>
@@ -2692,390 +1542,134 @@
     Node: <remap>
     Remap a value from one range of float/color/vector values to another.
   -->
-  <nodedef name="ND_remap_float" node="remap" nodegroup="adjustment">
-    <input name="in" type="float" value="0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_remap_color3" node="remap" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="inlow" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="inhigh" type="color3" value="1.0, 1.0, 1.0" />
-    <input name="outlow" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="outhigh" type="color3" value="1.0, 1.0, 1.0" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_remap_color4" node="remap" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inlow" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inhigh" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="outlow" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="outhigh" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_remap_vector2" node="remap" nodegroup="adjustment">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="inlow" type="vector2" value="0.0, 0.0" />
-    <input name="inhigh" type="vector2" value="1.0, 1.0" />
-    <input name="outlow" type="vector2" value="0.0, 0.0" />
-    <input name="outhigh" type="vector2" value="1.0, 1.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_remap_vector3" node="remap" nodegroup="adjustment">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="inlow" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="inhigh" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="outlow" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="outhigh" type="vector3" value="1.0, 1.0, 1.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_remap_vector4" node="remap" nodegroup="adjustment">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inlow" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="outlow" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="outhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_remap_color3FA" node="remap" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_remap_color4FA" node="remap" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_remap_vector2FA" node="remap" nodegroup="adjustment">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_remap_vector3FA" node="remap" nodegroup="adjustment">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_remap_vector4FA" node="remap" nodegroup="adjustment">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_remap" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_remap_@typeName@" node="remap" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="inlow" type="@typeName@" value="Value:zero" />
+      <input name="inhigh" type="@typeName@" value="Value:one" />
+      <input name="outlow" type="@typeName@" value="Value:zero" />
+      <input name="outhigh" type="@typeName@" value="Value:one" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
+
+  <template name="TP_ND_remapFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_remap_@typeName@FA" node="remap" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="inlow" type="float" value="0.0" />
+      <input name="inhigh" type="float" value="1.0" />
+      <input name="outlow" type="float" value="0.0" />
+      <input name="outhigh" type="float" value="1.0" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <smoothstep>
     Outputs a smooth (hermite-interpolated) remapping of input values from low-high
     to output 0-1.
   -->
-  <nodedef name="ND_smoothstep_float" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="float" value="0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_smoothstep_color3" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="low" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="high" type="color3" value="1.0, 1.0, 1.0" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_smoothstep_color4" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="low" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="high" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_smoothstep_vector2" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="low" type="vector2" value="0.0, 0.0" />
-    <input name="high" type="vector2" value="1.0, 1.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_smoothstep_vector3" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="low" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="high" type="vector3" value="1.0, 1.0, 1.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_smoothstep_vector4" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="low" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="high" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_smoothstep_color3FA" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_smoothstep_color4FA" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_smoothstep_vector2FA" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_smoothstep_vector3FA" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_smoothstep_vector4FA" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_smoothstep" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_smoothstep_@typeName@" node="smoothstep" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="low" type="@typeName@" value="Value:zero" />
+      <input name="high" type="@typeName@" value="Value:one" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
+
+  <template name="TP_ND_smoothstepFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_smoothstep_@typeName@FA" node="smoothstep" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
+
 
   <!--
     Node: <luminance>
     Output a grayscale image containing the luminance of the incoming RGB color in all color channels;
     the alpha channel is left unchanged if present.
   -->
-  <nodedef name="ND_luminance_color3" node="luminance" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_luminance_color4" node="luminance" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_luminance" varName="typeName" options="color3, color4">
+    <nodedef name="ND_luminance_@typeName@" node="luminance" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
 
   <!--
     Nodes: <rgbtohsv> and <hsvtorgb>
     Convert an incoming color between RGB and HSV space, with H and S ranging from 0-1.
   -->
-  <nodedef name="ND_rgbtohsv_color3" node="rgbtohsv" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_rgbtohsv_color4" node="rgbtohsv" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_hsvtorgb_color3" node="hsvtorgb" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_hsvtorgb_color4" node="hsvtorgb" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_rgbtohsv" varName="typeName" options="color3, color4">
+    <nodedef name="ND_rgbtohsv_@typeName@" node="rgbtohsv" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
+  <template name="TP_ND_hsvtorgb" varName="typeName" options="color3, color4">
+    <nodedef name="ND_hsvtorgb_@typeName@" node="hsvtorgb" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <contrast> Supplemental Node
     Increase or decrease contrast of a float/color value using a linear slope multiplier.
   -->
-  <nodedef name="ND_contrast_float" node="contrast" nodegroup="adjustment">
-    <input name="in" type="float" value="0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.5" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_contrast_color3" node="contrast" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="color3" value="1.0, 1.0, 1.0" />
-    <input name="pivot" type="color3" value="0.5, 0.5, 0.5" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_contrast_color4" node="contrast" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="pivot" type="color4" value="0.5, 0.5, 0.5, 0.5" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_contrast_vector2" node="contrast" nodegroup="adjustment">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="amount" type="vector2" value="1.0, 1.0" />
-    <input name="pivot" type="vector2" value="0.5, 0.5" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_contrast_vector3" node="contrast" nodegroup="adjustment">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="pivot" type="vector3" value="0.5, 0.5, 0.5" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_contrast_vector4" node="contrast" nodegroup="adjustment">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="pivot" type="vector4" value="0.5, 0.5, 0.5, 0.5" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_contrast_color3FA" node="contrast" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.5" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_contrast_color4FA" node="contrast" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.5" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_contrast_vector2FA" node="contrast" nodegroup="adjustment">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.5" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_contrast_vector3FA" node="contrast" nodegroup="adjustment">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.5" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_contrast_vector4FA" node="contrast" nodegroup="adjustment">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.5" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_contrast" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_contrast_@typeName@" node="contrast" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="amount" type="@typeName@" value="Value:one" />
+      <input name="pivot" type="@typeName@" value="Value:half" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
+
+  <template name="TP_ND_contrastFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_contrast_@typeName@FA" node="contrast" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="amount" type="float" value="1.0" />
+      <input name="pivot" type="float" value="0.5" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <range> Supplemental Node
     Remap a value from one range of float/color/vector values to another, optionally
     applying a gamma correction in the middle, and optionally clamping output values.
   -->
-  <nodedef name="ND_range_float" node="range" nodegroup="adjustment">
-    <input name="in" type="float" value="0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="gamma" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
-    <input name="doclamp" type="boolean" value="false" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_range_color3" node="range" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="inlow" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="inhigh" type="color3" value="1.0, 1.0, 1.0" />
-    <input name="gamma" type="color3" value="1.0, 1.0, 1.0" />
-    <input name="outlow" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="outhigh" type="color3" value="1.0, 1.0, 1.0" />
-    <input name="doclamp" type="boolean" value="false" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_range_color4" node="range" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inlow" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inhigh" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="gamma" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="outlow" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="outhigh" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="doclamp" type="boolean" value="false" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_range_vector2" node="range" nodegroup="adjustment">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="inlow" type="vector2" value="0.0, 0.0" />
-    <input name="inhigh" type="vector2" value="1.0, 1.0" />
-    <input name="gamma" type="vector2" value="1.0, 1.0" />
-    <input name="outlow" type="vector2" value="0.0, 0.0" />
-    <input name="outhigh" type="vector2" value="1.0, 1.0" />
-    <input name="doclamp" type="boolean" value="false" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_range_vector3" node="range" nodegroup="adjustment">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="inlow" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="inhigh" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="gamma" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="outlow" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="outhigh" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="doclamp" type="boolean" value="false" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_range_vector4" node="range" nodegroup="adjustment">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inlow" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="gamma" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="outlow" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="outhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="doclamp" type="boolean" value="false" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_range_color3FA" node="range" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="gamma" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
-    <input name="doclamp" type="boolean" value="false" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_range_color4FA" node="range" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="gamma" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
-    <input name="doclamp" type="boolean" value="false" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_range_vector2FA" node="range" nodegroup="adjustment">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="gamma" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
-    <input name="doclamp" type="boolean" value="false" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_range_vector3FA" node="range" nodegroup="adjustment">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="gamma" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
-    <input name="doclamp" type="boolean" value="false" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_range_vector4FA" node="range" nodegroup="adjustment">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="gamma" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
-    <input name="doclamp" type="boolean" value="false" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_range" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_range_@typeName@" node="range" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="inlow" type="@typeName@" value="Value:zero" />
+      <input name="inhigh" type="@typeName@" value="Value:one" />
+      <input name="gamma" type="@typeName@" value="Value:one" />
+      <input name="outlow" type="@typeName@" value="Value:zero" />
+      <input name="outhigh" type="@typeName@" value="Value:one" />
+      <input name="doclamp" type="boolean" value="false" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
+
+  <template name="TP_ND_rangeFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_range_@typeName@FA" node="range" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="inlow" type="float" value="0.0" />
+      <input name="inhigh" type="float" value="1.0" />
+      <input name="gamma" type="float" value="1.0" />
+      <input name="outlow" type="float" value="0.0" />
+      <input name="outhigh" type="float" value="1.0" />
+      <input name="doclamp" type="boolean" value="false" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <hsvadjust> Supplemental Node
@@ -3083,16 +1677,13 @@
     to HSV, adding amount.x to the hue, multiplying the saturation by amount.y,
     multiplying the value by amount.z, then converting back to RGB.
   -->
-  <nodedef name="ND_hsvadjust_color3" node="hsvadjust" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="vector3" value="0.0, 1.0, 1.0" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_hsvadjust_color4" node="hsvadjust" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="vector3" value="0.0, 1.0, 1.0" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_hsvadjust" varName="typeName" options="color3, color4">
+    <nodedef name="ND_hsvadjust_@typeName@" node="hsvadjust" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="amount" type="vector3" value="0.0, 1.0, 1.0" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <saturate> Supplemental Node
@@ -3100,48 +1691,34 @@
     color and the grayscale luminance of the input computed using the provided luma
     coefficients; the alpha channel will be unchanged if present.
   -->
-  <nodedef name="ND_saturate_color3" node="saturate" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_saturate_color4" node="saturate" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_saturate" varName="typeName" options="color3, color4">
+    <nodedef name="ND_saturate_@typeName@" node="saturate" nodegroup="math">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="amount" type="float" value="1.0" />
+      <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <colorcorrect> Supplemental Node
     Combines various adjustment nodes into one, artist-friendly color correction node.
     The color4 signature does not touch the alpha channel.
   -->
-  <nodedef name="ND_colorcorrect_color3" node="colorcorrect" nodegroup="adjustment">
-    <input name="in" type="color3" uiname="Input Color" value="1, 1, 1" doc="The input color to be adjusted." />
-    <input name="hue" type="float" uiname="Hue" uisoftmin="0.0" uisoftmax="1.0" value="0" doc="Rotates the color hue, with values wrapping at 0-1 boundaries." />
-    <input name="saturation" type="float" uiname="Saturation" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Adjusts the input color saturation level." />
-    <input name="gamma" type="float" uiname="Gamma" uisoftmin="0.0" uisoftmax="3.0" value="1" doc="Applies a gamma correction to the color." />
-    <input name="lift" type="float" uiname="Lift" uisoftmin="0.0" uisoftmax="1.0" value="0" doc="Raise the dark color values, leaving the white values unchanged." />
-    <input name="gain" type="float" uiname="Gain" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Multiplier increases lighter color values, leaving black values unchanged." />
-    <input name="contrast" type="float" uiname="Contrast" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Linearly increase or decrease the color contrast." />
-    <input name="contrastpivot" type="float" uiname="Contrast Pivot" uisoftmin="0.0" uisoftmax="1.0" value="0.5" doc="Pivot value around which contrast applies. This value will not change as contrast is adjusted." />
-    <input name="exposure" type="float" uiname="Exposure" uisoftmin="-1.0" uisoftmax="1.0" value="0" doc="Multiplier which increases or decreases color brightness by 2^value." />
-    <output name="out" type="color3" />
-  </nodedef>
-  <nodedef name="ND_colorcorrect_color4" node="colorcorrect" nodegroup="adjustment">
-    <input name="in" type="color4" uiname="Input Color" value="1, 1, 1, 0" doc="The input color to be adjusted." />
-    <input name="hue" type="float" uiname="Hue" uisoftmin="0.0" uisoftmax="1.0" value="0" doc="Rotates the color hue, with values wrapping at 0-1 boundaries." />
-    <input name="saturation" type="float" uiname="Saturation" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Adjusts the input color saturation level." />
-    <input name="gamma" type="float" uiname="Gamma" uisoftmin="0.0" uisoftmax="3.0" value="1" doc="Applies a gamma correction to the color." />
-    <input name="lift" type="float" uiname="Lift" uisoftmin="0.0" uisoftmax="1.0" value="0" doc="Raise the dark color values, leaving the white values unchanged." />
-    <input name="gain" type="float" uiname="Gain" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Multiplier increases lighter color values, leaving black values unchanged." />
-    <input name="contrast" type="float" uiname="Contrast" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Linearly increase or decrease the color contrast." />
-    <input name="contrastpivot" type="float" uiname="Contrast Pivot" uisoftmin="0.0" uisoftmax="1.0" value="0.5" doc="Pivot value around which contrast applies. This value will not change as contrast is adjusted." />
-    <input name="exposure" type="float" uiname="Exposure" uisoftmin="-1.0" uisoftmax="1.0" value="0" doc="Multiplier which increases or decreases color brightness by 2^value." />
-    <output name="out" type="color4" />
-  </nodedef>
+  <template name="TP_ND_colorcorrect" varName="typeName" options="color3, color4">
+    <nodedef name="ND_colorcorrect_@typeName@" node="colorcorrect" nodegroup="adjustment">
+      <input name="in" type="@typeName@" uiname="Input Color" value="Value:one" doc="The input color to be adjusted." />
+      <input name="hue" type="float" uiname="Hue" uisoftmin="0.0" uisoftmax="1.0" value="0" doc="Rotates the color hue, with values wrapping at 0-1 boundaries." />
+      <input name="saturation" type="float" uiname="Saturation" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Adjusts the input color saturation level." />
+      <input name="gamma" type="float" uiname="Gamma" uisoftmin="0.0" uisoftmax="3.0" value="1" doc="Applies a gamma correction to the color." />
+      <input name="lift" type="float" uiname="Lift" uisoftmin="0.0" uisoftmax="1.0" value="0" doc="Raise the dark color values, leaving the white values unchanged." />
+      <input name="gain" type="float" uiname="Gain" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Multiplier increases lighter color values, leaving black values unchanged." />
+      <input name="contrast" type="float" uiname="Contrast" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Linearly increase or decrease the color contrast." />
+      <input name="contrastpivot" type="float" uiname="Contrast Pivot" uisoftmin="0.0" uisoftmax="1.0" value="0.5" doc="Pivot value around which contrast applies. This value will not change as contrast is adjusted." />
+      <input name="exposure" type="float" uiname="Exposure" uisoftmin="-1.0" uisoftmax="1.0" value="0" doc="Multiplier which increases or decreases color brightness by 2^value." />
+      <output name="out" type="@typeName@" />
+    </nodedef>
+  </template>
 
   <!-- ======================================================================== -->
   <!-- Compositing nodes                                                        -->
@@ -3170,140 +1747,80 @@
     Node: <plus>
     Add two 1-4 channel inputs, with optional mixing between the bg input and the result.
   -->
-  <nodedef name="ND_plus_float" node="plus" nodegroup="compositing">
-    <input name="fg" type="float" value="0.0" />
-    <input name="bg" type="float" value="0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="float" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_plus_color3" node="plus" nodegroup="compositing">
-    <input name="fg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="color3" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_plus_color4" node="plus" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="color4" defaultinput="bg" />
-  </nodedef>
+  <template name="TP_ND_plus" varName="typeName" options="float, color3, color4">
+    <nodedef name="ND_plus_@typeName@" node="plus" nodegroup="compositing">
+      <input name="fg" type="@typeName@" value="Value:zero" />
+      <input name="bg" type="@typeName@" value="Value:zero" />
+      <input name="mix" type="float" value="1.0" />
+      <output name="out" type="@typeName@" defaultinput="bg" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <minus>
     Subtract two 1-4 channel inputs, with optional mixing between the bg input and the result.
   -->
-  <nodedef name="ND_minus_float" node="minus" nodegroup="compositing">
-    <input name="fg" type="float" value="0.0" />
-    <input name="bg" type="float" value="0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="float" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_minus_color3" node="minus" nodegroup="compositing">
-    <input name="fg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="color3" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_minus_color4" node="minus" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="color4" defaultinput="bg" />
-  </nodedef>
+  <template name="TP_ND_minus" varName="typeName" options="float, color3, color4">
+    <nodedef name="ND_minus_@typeName@" node="minus" nodegroup="compositing">
+      <input name="fg" type="@typeName@" value="Value:zero" />
+      <input name="bg" type="@typeName@" value="Value:zero" />
+      <input name="mix" type="float" value="1.0" />
+      <output name="out" type="@typeName@" defaultinput="bg" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <difference>
     Absolute-value difference of two 1-4 channel inputs, with optional mixing between
     the bg input and the result.
   -->
-  <nodedef name="ND_difference_float" node="difference" nodegroup="compositing">
-    <input name="fg" type="float" value="0.0" />
-    <input name="bg" type="float" value="0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="float" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_difference_color3" node="difference" nodegroup="compositing">
-    <input name="fg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="color3" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_difference_color4" node="difference" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="color4" defaultinput="bg" />
-  </nodedef>
+  <template name="TP_ND_difference" varName="typeName" options="float, color3, color4">
+    <nodedef name="ND_difference_@typeName@" node="difference" nodegroup="compositing">
+      <input name="fg" type="@typeName@" value="Value:zero" />
+      <input name="bg" type="@typeName@" value="Value:zero" />
+      <input name="mix" type="float" value="1.0" />
+      <output name="out" type="@typeName@" defaultinput="bg" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <burn>
     Take two 1-4 channel inputs and apply the same operator to all channels: 1-(1-B)/F
   -->
-  <nodedef name="ND_burn_float" node="burn" nodegroup="compositing">
-    <input name="fg" type="float" value="0.0" />
-    <input name="bg" type="float" value="0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="float" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_burn_color3" node="burn" nodegroup="compositing">
-    <input name="fg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="color3" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_burn_color4" node="burn" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="color4" defaultinput="bg" />
-  </nodedef>
+  <template name="TP_ND_burn" varName="typeName" options="float, color3, color4">
+    <nodedef name="ND_burn_@typeName@" node="burn" nodegroup="compositing">
+      <input name="fg" type="@typeName@" value="Value:zero" />
+      <input name="bg" type="@typeName@" value="Value:zero" />
+      <input name="mix" type="float" value="1.0" />
+      <output name="out" type="@typeName@" defaultinput="bg" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <dodge>
     Take two 1-4 channel inputs and apply the same operator to all channels: B/(1-F)
   -->
-  <nodedef name="ND_dodge_float" node="dodge" nodegroup="compositing">
-    <input name="fg" type="float" value="0.0" />
-    <input name="bg" type="float" value="0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="float" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_dodge_color3" node="dodge" nodegroup="compositing">
-    <input name="fg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="color3" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_dodge_color4" node="dodge" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="color4" defaultinput="bg" />
-  </nodedef>
+  <template name="TP_ND_dodge" varName="typeName" options="float, color3, color4">
+    <nodedef name="ND_dodge_@typeName@" node="dodge" nodegroup="compositing">
+      <input name="fg" type="@typeName@" value="Value:zero" />
+      <input name="bg" type="@typeName@" value="Value:zero" />
+      <input name="mix" type="float" value="1.0" />
+      <output name="out" type="@typeName@" defaultinput="bg" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <screen>
     Take two 1-4 channel inputs and apply the same operator to all channels: 1-(1-F)*(1-B)
   -->
-  <nodedef name="ND_screen_float" node="screen" nodegroup="compositing">
-    <input name="fg" type="float" value="0.0" />
-    <input name="bg" type="float" value="0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="float" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_screen_color3" node="screen" nodegroup="compositing">
-    <input name="fg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="color3" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_screen_color4" node="screen" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="color4" defaultinput="bg" />
-  </nodedef>
+  <template name="TP_ND_screen" varName="typeName" options="float, color3, color4">
+    <nodedef name="ND_screen_@typeName@" node="screen" nodegroup="compositing">
+      <input name="fg" type="@typeName@" value="Value:zero" />
+      <input name="bg" type="@typeName@" value="Value:zero" />
+      <input name="mix" type="float" value="1.0" />
+      <output name="out" type="@typeName@" defaultinput="bg" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <overlay>
@@ -3311,24 +1828,14 @@
       2FB if B<0.5;
       1-2(1-F)(1-B) if B>=0.5
   -->
-  <nodedef name="ND_overlay_float" node="overlay" nodegroup="compositing">
-    <input name="fg" type="float" value="0.0" />
-    <input name="bg" type="float" value="0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="float" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_overlay_color3" node="overlay" nodegroup="compositing">
-    <input name="fg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="color3" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_overlay_color4" node="overlay" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
-    <output name="out" type="color4" defaultinput="bg" />
-  </nodedef>
+  <template name="TP_ND_overlay" varName="typeName" options="float, color3, color4">
+    <nodedef name="ND_overlay_@typeName@" node="overlay" nodegroup="compositing">
+      <input name="fg" type="@typeName@" value="Value:zero" />
+      <input name="bg" type="@typeName@" value="Value:zero" />
+      <input name="mix" type="float" value="1.0" />
+      <output name="out" type="@typeName@" defaultinput="bg" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <disjointover>
@@ -3410,131 +1917,48 @@
     Take one 1-4 channel input "in" plus a separate float "mask" input and apply the same
     operator to all channels: in * mask
   -->
-  <nodedef name="ND_inside_float" node="inside" nodegroup="compositing">
-    <input name="in" type="float" value="0.0" />
-    <input name="mask" type="float" value="1.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_inside_color3" node="inside" nodegroup="compositing">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mask" type="float" value="1.0" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_inside_color4" node="inside" nodegroup="compositing">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mask" type="float" value="1.0" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_inside" varName="typeName" options="float, color3, color4">
+    <nodedef name="ND_inside_@typeName@" node="inside" nodegroup="compositing">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="mask" type="@typeName@" value="Value:one" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <outside>
     Take one 1-4 channel input "in" plus a separate float "mask" input and apply the same
     operator to all channels: in * (1-mask)
   -->
-  <nodedef name="ND_outside_float" node="outside" nodegroup="compositing">
-    <input name="in" type="float" value="0.0" />
-    <input name="mask" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_outside_color3" node="outside" nodegroup="compositing">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mask" type="float" value="0.0" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_outside_color4" node="outside" nodegroup="compositing">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mask" type="float" value="0.0" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_outside" varName="typeName" options="float, color3, color4">
+    <nodedef name="ND_outside_@typeName@" node="outside" nodegroup="compositing">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="mask" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <mix>
     Mix two inputs according to an input mix amount.
   -->
-  <nodedef name="ND_mix_float" node="mix" nodegroup="compositing">
-    <input name="fg" type="float" value="0.0" />
-    <input name="bg" type="float" value="0.0" />
-    <input name="mix" type="float" value="0.0" uisoftmin="0.0" uisoftmax="1.0" />
-    <output name="out" type="float" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_mix_color3" node="mix" nodegroup="compositing">
-    <input name="fg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="0.0" uisoftmin="0.0" uisoftmax="1.0" />
-    <output name="out" type="color3" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_mix_color3_color3" node="mix" nodegroup="compositing">
-    <input name="fg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="color3" value="0.0, 0.0, 0.0" uisoftmin="0,0,0" uisoftmax="1,1,1" />
-    <output name="out" type="color3" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_mix_color4" node="mix" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="0.0" uisoftmin="0.0" uisoftmax="1.0" />
-    <output name="out" type="color4" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_mix_color4_color4" node="mix" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="color4" value="0.0, 0.0, 0.0, 0.0" uisoftmin="0,0,0,0" uisoftmax="1,1,1,1" />
-    <output name="out" type="color4" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_mix_vector2" node="mix" nodegroup="compositing">
-    <input name="fg" type="vector2" value="0.0, 0.0" />
-    <input name="bg" type="vector2" value="0.0, 0.0" />
-    <input name="mix" type="float" value="0.0" uisoftmin="0.0" uisoftmax="1.0" />
-    <output name="out" type="vector2" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_mix_vector2_vector2" node="mix" nodegroup="compositing">
-    <input name="fg" type="vector2" value="0.0, 0.0" />
-    <input name="bg" type="vector2" value="0.0, 0.0" />
-    <input name="mix" type="vector2" value="0.0, 0.0" uisoftmin="0,0" uisoftmax="1,1" />
-    <output name="out" type="vector2" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_mix_vector3" node="mix" nodegroup="compositing">
-    <input name="fg" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="0.0" uisoftmin="0.0" uisoftmax="1.0" />
-    <output name="out" type="vector3" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_mix_vector3_vector3" node="mix" nodegroup="compositing">
-    <input name="fg" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="vector3" value="0.0, 0.0, 0.0" uisoftmin="0,0,0" uisoftmax="1,1,1" />
-    <output name="out" type="vector3" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_mix_vector4" node="mix" nodegroup="compositing">
-    <input name="fg" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="0.0" uisoftmin="0.0" uisoftmax="1.0" />
-    <output name="out" type="vector4" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_mix_vector4_vector4" node="mix" nodegroup="compositing">
-    <input name="fg" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="vector4" value="0.0, 0.0, 0.0, 0.0" uisoftmin="0,0,0,0" uisoftmax="1,1,1,1" />
-    <output name="out" type="vector4" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_mix_surfaceshader" node="mix" nodegroup="compositing">
-    <input name="fg" type="surfaceshader" value="" />
-    <input name="bg" type="surfaceshader" value="" />
-    <input name="mix" type="float" value="0.0" uisoftmin="0.0" uisoftmax="1.0" />
-    <output name="out" type="surfaceshader" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_mix_displacementshader" node="mix" nodegroup="compositing">
-    <input name="fg" type="displacementshader" value="" />
-    <input name="bg" type="displacementshader" value="" />
-    <input name="mix" type="float" value="0.0" uisoftmin="0.0" uisoftmax="1.0" />
-    <output name="out" type="displacementshader" defaultinput="bg" />
-  </nodedef>
-  <nodedef name="ND_mix_volumeshader" node="mix" nodegroup="compositing">
-    <input name="fg" type="volumeshader" value="" />
-    <input name="bg" type="volumeshader" value="" />
-    <input name="mix" type="float" value="0.0" uisoftmin="0.0" uisoftmax="1.0" />
-    <output name="out" type="volumeshader" defaultinput="bg" />
-  </nodedef>
+  <template name="TP_ND_mix" varName="typeName" options="float, color3, color4, vector2, vector3, vector4, surfaceshader, displacementshader, volumeshader">
+    <nodedef name="ND_mix_@typeName@" node="mix" nodegroup="compositing">
+      <input name="fg" type="@typeName@" value="Value:zero" />
+      <input name="bg" type="@typeName@" value="Value:zero" />
+      <input name="mix" type="float" value="0.0" uisoftmin="0.0" uisoftmax="1.0" />
+      <output name="out" type="@typeName@" defaultinput="bg" />
+    </nodedef>
+  </template>
+
+  <template name="TP_ND_mix_self" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_mix_@typeName@_@typeName@" node="mix" nodegroup="compositing">
+      <input name="fg" type="@typeName@" value="Value:zero" />
+      <input name="bg" type="@typeName@" value="Value:zero" />
+      <input name="mix" type="@typeName@" value="Value:zero" uisoftmin="0,0,0" uisoftmax="1,1,1" />
+      <output name="out" type="@typeName@" defaultinput="bg" />
+    </nodedef>
+  </template>
 
   <!-- ======================================================================== -->
   <!-- Conditional nodes                                                        -->
@@ -3544,721 +1968,112 @@
     Node: <ifgreater>
     Output the value of in1 if value1>value2, or the value of in2 if value1<=value2.
   -->
-  <nodedef name="ND_ifgreater_float" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreater_integer" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
-    <output name="out" type="integer" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreater_color3" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreater_color4" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreater_vector2" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreater_vector3" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreater_vector4" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreater_matrix33" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="matrix33" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreater_matrix44" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="matrix44" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreater_boolean" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <output name="out" type="boolean" default="false" />
-  </nodedef>
-  <nodedef name="ND_ifgreater_floatI" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreater_integerI" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
-    <output name="out" type="integer" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreater_color3I" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreater_color4I" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreater_vector2I" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreater_vector3I" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreater_vector4I" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreater_matrix33I" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="matrix33" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreater_matrix44I" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="matrix44" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreater_booleanI" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <output name="out" type="boolean" default="false" />
-  </nodedef>
+  <template name="TP_ND_ifgreater" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4, matrix33, matrix44, boolean">
+    <nodedef name="ND_ifgreater_@typeName@" node="ifgreater" nodegroup="conditional">
+      <input name="value1" type="float" value="1.0" />
+      <input name="value2" type="float" value="0.0" />
+      <input name="in1" type="@typeName@" value="0.0" />
+      <input name="in2" type="@typeName@" value="0.0" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+
+  <template name="TP_ND_ifgreater_I" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4, matrix33, matrix44, boolean">
+    <nodedef name="ND_ifgreater_@typeName@I" node="ifgreater" nodegroup="conditional">
+      <input name="value1" type="integer" value="1" />
+      <input name="value2" type="integer" value="0" />
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <ifgreatereq>
     Output the value of in1 if value1>=value2, or the value of in2 if value1<value2.
   -->
-  <nodedef name="ND_ifgreatereq_float" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreatereq_integer" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
-    <output name="out" type="integer" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreatereq_color3" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreatereq_color4" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreatereq_vector2" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreatereq_vector3" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreatereq_vector4" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreatereq_matrix33" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="matrix33" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreatereq_matrix44" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="matrix44" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreatereq_boolean" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <output name="out" type="boolean" default="false" />
-  </nodedef>
-  <nodedef name="ND_ifgreatereq_floatI" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreatereq_integerI" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
-    <output name="out" type="integer" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreatereq_color3I" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreatereq_color4I" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreatereq_vector2I" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreatereq_vector3I" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreatereq_vector4I" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreatereq_matrix33I" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="matrix33" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreatereq_matrix44I" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="matrix44" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifgreatereq_booleanI" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <output name="out" type="boolean" default="false" />
-  </nodedef>
+  <template name="TP_ND_ifgreatereq" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4, matrix33, matrix44, boolean">
+    <nodedef name="ND_ifgreatereq_@typeName@" node="ifgreatereq" nodegroup="conditional">
+      <input name="value1" type="float" value="1.0" />
+      <input name="value2" type="float" value="0.0" />
+      <input name="in1" type="@typeName@" value="0.0" />
+      <input name="in2" type="@typeName@" value="0.0" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+
+  <template name="TP_ND_ifgreatereq_I" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4, matrix33, matrix44, boolean">
+    <nodedef name="ND_ifgreatereq_@typeName@I" node="ifgreatereq" nodegroup="conditional">
+      <input name="value1" type="integer" value="1" />
+      <input name="value2" type="integer" value="0" />
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <ifequal>
     Output the value of in1 if value1==value2, or the value of in2 if value1!=value2.
   -->
-  <nodedef name="ND_ifequal_float" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="0.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_integer" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="0.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
-    <output name="out" type="integer" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_color3" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="0.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_color4" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="0.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_vector2" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="0.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_vector3" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="0.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_vector4" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="0.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_matrix33" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="0.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="matrix33" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_matrix44" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="0.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="matrix44" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_boolean" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <output name="out" type="boolean" default="false" />
-  </nodedef>
-  <nodedef name="ND_ifequal_floatI" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="0" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_integerI" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="0" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
-    <output name="out" type="integer" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_color3I" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="0" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_color4I" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="0" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_vector2I" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="0" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_vector3I" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="0" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_vector4I" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="0" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_matrix33I" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="0" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="matrix33" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_matrix44I" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="0" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="matrix44" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_booleanI" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <output name="out" type="boolean" default="false" />
-  </nodedef>
-  <nodedef name="ND_ifequal_floatB" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_integerB" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
-    <output name="out" type="integer" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_color3B" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_color4B" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_vector2B" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_vector3B" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_vector4B" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_matrix33B" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
-    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="matrix33" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_matrix44B" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
-    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="matrix44" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_ifequal_booleanB" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
-    <output name="out" type="boolean" default="false" />
-  </nodedef>
+  <template name="TP_ND_ifequal" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4, matrix33, matrix44, boolean">
+    <nodedef name="ND_ifequal_@typeName@" node="ifequal" nodegroup="conditional">
+      <input name="value1" type="float" value="0.0" />
+      <input name="value2" type="float" value="0.0" />
+      <input name="in1" type="@typeName@" value="0.0" />
+      <input name="in2" type="@typeName@" value="0.0" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+
+  <template name="TP_ND_ifequal_I" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4, matrix33, matrix44, boolean">
+    <nodedef name="ND_ifequal_@typeName@I" node="ifequal" nodegroup="conditional">
+      <input name="value1" type="integer" value="0" />
+      <input name="value2" type="integer" value="0" />
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <switch>
     Pass on the value of one of five input streams, according to the value of a selector parameter.
   -->
-  <nodedef name="ND_switch_float" node="switch" nodegroup="conditional">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <input name="in3" type="float" value="0.0" />
-    <input name="in4" type="float" value="0.0" />
-    <input name="in5" type="float" value="0.0" />
-    <input name="in6" type="float" value="0.0" />
-    <input name="in7" type="float" value="0.0" />
-    <input name="in8" type="float" value="0.0" />
-    <input name="in9" type="float" value="0.0" />
-    <input name="in10" type="float" value="0.0" />
-    <input name="which" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_switch_color3" node="switch" nodegroup="conditional">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in3" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in4" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in5" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in6" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in7" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in8" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in9" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in10" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="which" type="float" value="0.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_switch_color4" node="switch" nodegroup="conditional">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in3" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in4" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in5" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in6" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in7" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in8" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in9" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in10" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="which" type="float" value="0.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_switch_vector2" node="switch" nodegroup="conditional">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
-    <input name="in3" type="vector2" value="0.0, 0.0" />
-    <input name="in4" type="vector2" value="0.0, 0.0" />
-    <input name="in5" type="vector2" value="0.0, 0.0" />
-    <input name="in6" type="vector2" value="0.0, 0.0" />
-    <input name="in7" type="vector2" value="0.0, 0.0" />
-    <input name="in8" type="vector2" value="0.0, 0.0" />
-    <input name="in9" type="vector2" value="0.0, 0.0" />
-    <input name="in10" type="vector2" value="0.0, 0.0" />
-    <input name="which" type="float" value="0.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_switch_vector3" node="switch" nodegroup="conditional">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in3" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in4" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in5" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in6" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in7" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in8" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in9" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in10" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="which" type="float" value="0.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_switch_vector4" node="switch" nodegroup="conditional">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in3" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in4" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in5" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in6" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in7" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in8" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in9" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in10" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="which" type="float" value="0.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_switch_matrix33" node="switch" nodegroup="conditional">
-    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in3" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in4" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in5" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in6" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in7" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in8" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in9" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in10" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="which" type="float" value="0.0" />
-    <output name="out" type="matrix33" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_switch_matrix44" node="switch" nodegroup="conditional">
-    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in3" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in4" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in5" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in6" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in7" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in8" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in9" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in10" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="which" type="float" value="0.0" />
-    <output name="out" type="matrix44" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_switch_floatI" node="switch" nodegroup="conditional">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <input name="in3" type="float" value="0.0" />
-    <input name="in4" type="float" value="0.0" />
-    <input name="in5" type="float" value="0.0" />
-    <input name="in6" type="float" value="0.0" />
-    <input name="in7" type="float" value="0.0" />
-    <input name="in8" type="float" value="0.0" />
-    <input name="in9" type="float" value="0.0" />
-    <input name="in10" type="float" value="0.0" />
-    <input name="which" type="integer" value="0" />
-    <output name="out" type="float" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_switch_color3I" node="switch" nodegroup="conditional">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in3" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in4" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in5" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in6" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in7" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in8" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in9" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in10" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="which" type="integer" value="0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_switch_color4I" node="switch" nodegroup="conditional">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in3" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in4" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in5" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in6" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in7" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in8" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in9" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in10" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="which" type="integer" value="0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_switch_vector2I" node="switch" nodegroup="conditional">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
-    <input name="in3" type="vector2" value="0.0, 0.0" />
-    <input name="in4" type="vector2" value="0.0, 0.0" />
-    <input name="in5" type="vector2" value="0.0, 0.0" />
-    <input name="in6" type="vector2" value="0.0, 0.0" />
-    <input name="in7" type="vector2" value="0.0, 0.0" />
-    <input name="in8" type="vector2" value="0.0, 0.0" />
-    <input name="in9" type="vector2" value="0.0, 0.0" />
-    <input name="in10" type="vector2" value="0.0, 0.0" />
-    <input name="which" type="integer" value="0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_switch_vector3I" node="switch" nodegroup="conditional">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in3" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in4" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in5" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in6" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in7" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in8" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in9" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in10" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="which" type="integer" value="0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_switch_vector4I" node="switch" nodegroup="conditional">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in3" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in4" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in5" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in6" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in7" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in8" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in9" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in10" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="which" type="integer" value="0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_switch_matrix33I" node="switch" nodegroup="conditional">
-    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in3" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in4" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in5" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in6" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in7" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in8" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in9" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in10" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="which" type="integer" value="0" />
-    <output name="out" type="matrix33" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_switch_matrix44I" node="switch" nodegroup="conditional">
-    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in3" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in4" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in5" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in6" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in7" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in8" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in9" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in10" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="which" type="integer" value="0" />
-    <output name="out" type="matrix44" defaultinput="in1" />
-  </nodedef>
+  <template name="TP_ND_switch" varName="typeName" options="float, color3, color4, vector2, vector3, vector4, matrix33, matrix44">
+    <nodedef name="ND_switch_@typeName@" node="switch" nodegroup="conditional">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:zero" />
+      <input name="in3" type="@typeName@" value="Value:zero" />
+      <input name="in4" type="@typeName@" value="Value:zero" />
+      <input name="in5" type="@typeName@" value="Value:zero" />
+      <input name="in6" type="@typeName@" value="Value:zero" />
+      <input name="in7" type="@typeName@" value="Value:zero" />
+      <input name="in8" type="@typeName@" value="Value:zero" />
+      <input name="in9" type="@typeName@" value="Value:zero" />
+      <input name="in10" type="@typeName@" value="Value:zero" />
+      <input name="which" type="float" value="0.0" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+
+  <template name="TP_ND_switchI" varName="typeName" options="float, color3, color4, vector2, vector3, vector4, matrix33, matrix44">
+    <nodedef name="ND_switch_@typeName@I" node="switch" nodegroup="conditional">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:zero" />
+      <input name="in3" type="@typeName@" value="Value:zero" />
+      <input name="in4" type="@typeName@" value="Value:zero" />
+      <input name="in5" type="@typeName@" value="Value:zero" />
+      <input name="in6" type="@typeName@" value="Value:zero" />
+      <input name="in7" type="@typeName@" value="Value:zero" />
+      <input name="in8" type="@typeName@" value="Value:zero" />
+      <input name="in9" type="@typeName@" value="Value:zero" />
+      <input name="in10" type="@typeName@" value="Value:zero" />
+      <input name="which" type="integer" value="0" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+
 
   <!-- ======================================================================== -->
   <!-- Channel nodes                                                            -->
@@ -4269,202 +2084,68 @@
     Convert a stream from one type to another; only certain unambiguous conversion
     types are supported.
   -->
-  <nodedef name="ND_convert_float_color3" node="convert" nodegroup="channel">
-    <input name="in" type="float" value="0.0" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_float_color4" node="convert" nodegroup="channel">
-    <input name="in" type="float" value="0.0" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_float_vector2" node="convert" nodegroup="channel">
-    <input name="in" type="float" value="0.0" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_float_vector3" node="convert" nodegroup="channel">
-    <input name="in" type="float" value="0.0" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_float_vector4" node="convert" nodegroup="channel">
-    <input name="in" type="float" value="0.0" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_convert_float" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_convert_float_@typeName@" node="convert" nodegroup="channel">
+      <input name="in" type="float" value="0.0" />
+      <output name="out" type="@typeName@" default="Value:0" />
+    </nodedef>
+  </template>
 
-  <nodedef name="ND_convert_color3_color4" node="convert" nodegroup="channel">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_color3_vector2" node="convert" nodegroup="channel">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_color3_vector3" node="convert" nodegroup="channel">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_color3_vector4" node="convert" nodegroup="channel">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_convert_color3" varName="typeName" options="color4, vector2, vector3, vector4">
+    <nodedef name="ND_convert_color3_@typeName@" node="convert" nodegroup="channel">
+      <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
-  <nodedef name="ND_convert_color4_color3" node="convert" nodegroup="channel">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_color4_vector2" node="convert" nodegroup="channel">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_color4_vector3" node="convert" nodegroup="channel">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_color4_vector4" node="convert" nodegroup="channel">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_convert_color4" varName="typeName" options="color3, vector2, vector3, vector4">
+    <nodedef name="ND_convert_color4_@typeName@" node="convert" nodegroup="channel">
+      <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
-  <nodedef name="ND_convert_vector2_color3" node="convert" nodegroup="channel">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_vector2_color4" node="convert" nodegroup="channel">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_vector2_vector3" node="convert" nodegroup="channel">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_vector2_vector4" node="convert" nodegroup="channel">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_convert_vector2" varName="typeName" options="color3, color4, vector3, vector4">
+    <nodedef name="ND_convert_vector2_@typeName@" node="convert" nodegroup="channel">
+      <input name="in" type="vector2" value="0.0, 0.0" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
-  <nodedef name="ND_convert_vector3_color3" node="convert" nodegroup="channel">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_vector3_color4" node="convert" nodegroup="channel">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_vector3_vector2" node="convert" nodegroup="channel">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_vector3_vector4" node="convert" nodegroup="channel">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_convert_vector3" varName="typeName" options="color3, color4, vector2, vector4">
+    <nodedef name="ND_convert_vector3_@typeName@" node="convert" nodegroup="channel">
+      <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
-  <nodedef name="ND_convert_vector4_color3" node="convert" nodegroup="channel">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_vector4_color4" node="convert" nodegroup="channel">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_vector4_vector2" node="convert" nodegroup="channel">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_vector4_vector3" node="convert" nodegroup="channel">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_convert_vector4" varName="typeName" options="color3, color4, vector2, vector3">
+    <nodedef name="ND_convert_vector4_@typeName@" node="convert" nodegroup="channel">
+      <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
-  <nodedef name="ND_convert_boolean_float" node="convert" nodegroup="channel">
-    <input name="in" type="boolean" value="false" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_boolean_color3" node="convert" nodegroup="channel">
-    <input name="in" type="boolean" value="false" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_boolean_color4" node="convert" nodegroup="channel">
-    <input name="in" type="boolean" value="false" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_boolean_vector2" node="convert" nodegroup="channel">
-    <input name="in" type="boolean" value="false" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_boolean_vector3" node="convert" nodegroup="channel">
-    <input name="in" type="boolean" value="false" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_boolean_vector4" node="convert" nodegroup="channel">
-    <input name="in" type="boolean" value="false" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_boolean_integer" node="convert" nodegroup="channel">
-    <input name="in" type="boolean" value="false" />
-    <output name="out" type="integer" default="0" />
-  </nodedef>
+  <template name="TP_ND_convert_boolean" varName="typeName" options="float, color3, color4, vector2, vector3, vector4, integer">
+    <nodedef name="ND_convert_boolean_@typeName@" node="convert" nodegroup="channel">
+      <input name="in" type="boolean" value="false" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
-  <nodedef name="ND_convert_integer_float" node="convert" nodegroup="channel">
-    <input name="in" type="integer" value="0" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_integer_color3" node="convert" nodegroup="channel">
-    <input name="in" type="integer" value="0" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_integer_color4" node="convert" nodegroup="channel">
-    <input name="in" type="integer" value="0" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_integer_vector2" node="convert" nodegroup="channel">
-    <input name="in" type="integer" value="0" />
-    <output name="out" type="vector2" default="0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_integer_vector3" node="convert" nodegroup="channel">
-    <input name="in" type="integer" value="0" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_integer_vector4" node="convert" nodegroup="channel">
-    <input name="in" type="integer" value="0" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_convert_integer_boolean" node="convert" nodegroup="channel">
-    <input name="in" type="integer" value="0" />
-    <output name="out" type="boolean" default="false" />
-  </nodedef>
+  <template name="TP_ND_convert_integer" varName="typeName" options="float, color3, color4, vector2, vector3, vector4, boolean">
+    <nodedef name="ND_convert_integer_@typeName@" node="convert" nodegroup="channel">
+      <input name="in" type="integer" value="0" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
-  <nodedef name="ND_convert_color3_surfaceshader" node="convert" version="1.0" isdefaultversion="true" nodegroup="shader" doc="Convert color3 to shader">
-    <input name="in" type="color3" value="0, 0, 0" />
-    <output name="out" type="surfaceshader" />
-  </nodedef>
-  <nodedef name="ND_convert_color4_surfaceshader" node="convert" version="1.0" isdefaultversion="true" nodegroup="shader" doc="Convert color4  to shader">
-    <input name="in" type="color4" value="0, 0, 0, 0" />
-    <output name="out" type="surfaceshader" />
-  </nodedef>
-  <nodedef name="ND_convert_float_surfaceshader" node="convert" version="1.0" isdefaultversion="true" nodegroup="shader" doc="Convert float to shader">
-    <input name="in" type="float" value="0" />
-    <output name="out" type="surfaceshader" />
-  </nodedef>
-  <nodedef name="ND_convert_vector2_surfaceshader" node="convert" version="1.0" isdefaultversion="true" nodegroup="shader" doc="Convert vector2 to shader">
-    <input name="in" type="vector2" value="0, 0" />
-    <output name="out" type="surfaceshader" />
-  </nodedef>
-  <nodedef name="ND_convert_vector3_surfaceshader" node="convert" version="1.0" isdefaultversion="true" nodegroup="shader" doc="Convert vector2 to shader">
-    <input name="in" type="vector3" value="0, 0, 0" />
-    <output name="out" type="surfaceshader" />
-  </nodedef>
-  <nodedef name="ND_convert_vector4_surfaceshader" node="convert" version="1.0" isdefaultversion="true" nodegroup="shader" doc="Convert vector4 to shader">
-    <input name="in" type="vector4" value="0, 0, 0, 0" />
-    <output name="out" type="surfaceshader" />
-  </nodedef>
-  <nodedef name="ND_convert_integer_surfaceshader" node="convert" version="1.0" isdefaultversion="true" nodegroup="shader" doc="Convert integer to shader">
-    <input name="in" type="integer" value="0" />
-    <output name="out" type="surfaceshader" />
-  </nodedef>
-  <nodedef name="ND_convert_boolean_surfaceshader" node="convert" version="1.0" isdefaultversion="true" nodegroup="shader" doc="Convert boolean to shader">
-    <input name="in" type="boolean" value="false" />
-    <output name="out" type="surfaceshader" />
-  </nodedef>
+  <template name="TP_ND_convert_surfaceshader" varName="typeName" options="float, color3, color4, vector2, vector3, vector4, integer, boolean">
+    <nodedef name="ND_convert_@typeName@_surfaceshader" node="convert" version="1.0" isdefaultversion="true" nodegroup="shader" doc="Convert @typeName@ to shader">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <output name="out" type="surfaceshader" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <combine2>
@@ -4497,38 +2178,29 @@
     Combine the channels from three streams into the same number of channels of a
     single output stream of a specified compatible type.
   -->
-  <nodedef name="ND_combine3_color3" node="combine3" nodegroup="channel">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <input name="in3" type="float" value="0.0" />
-    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_combine3_vector3" node="combine3" nodegroup="channel">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <input name="in3" type="float" value="0.0" />
-    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_combine3" varName="typeName" options="color3, vector3">
+    <nodedef name="ND_combine3_@typeName@" node="combine3" nodegroup="channel">
+      <input name="in1" type="float" value="0.0" />
+      <input name="in2" type="float" value="0.0" />
+      <input name="in3" type="float" value="0.0" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <combine4>
     Combine the channels from four streams into the same number of channels of a
     single output stream of a specified compatible type.
   -->
-  <nodedef name="ND_combine4_color4" node="combine4" nodegroup="channel">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <input name="in3" type="float" value="0.0" />
-    <input name="in4" type="float" value="0.0" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
-  <nodedef name="ND_combine4_vector4" node="combine4" nodegroup="channel">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <input name="in3" type="float" value="0.0" />
-    <input name="in4" type="float" value="0.0" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
-  </nodedef>
+  <template name="TP_ND_combine3" varName="typeName" options="color4, vector4">
+    <nodedef name="ND_combine4_@typeName@" node="combine4" nodegroup="channel">
+      <input name="in1" type="float" value="0.0" />
+      <input name="in2" type="float" value="0.0" />
+      <input name="in3" type="float" value="0.0" />
+      <input name="in4" type="float" value="0.0" />
+      <output name="out" type="@typeName@" default="Value:zero" />
+    </nodedef>
+  </template>
 
   <!--
     Node <creatematrix>
@@ -4561,31 +2233,13 @@
     Node: <extract>
     Extract a single channel from a colorN or vectorN stream, outputting a float.
   -->
-  <nodedef name="ND_extract_color3" node="extract" nodegroup="channel">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="index" type="integer" value="0" uimin="0" uimax="2" uniform="true" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_extract_color4" node="extract" nodegroup="channel">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="index" type="integer" value="0" uimin="0" uimax="3" uniform="true" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_extract_vector2" node="extract" nodegroup="channel">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="index" type="integer" value="0" uimin="0" uimax="1" uniform="true" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_extract_vector3" node="extract" nodegroup="channel">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="index" type="integer" value="0" uimin="0" uimax="2" uniform="true" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
-  <nodedef name="ND_extract_vector4" node="extract" nodegroup="channel">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="index" type="integer" value="0" uimin="0" uimax="3" uniform="true" />
-    <output name="out" type="float" default="0.0" />
-  </nodedef>
+  <template name="TP_ND_extract" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_extract_@typeName@" node="extract" nodegroup="channel">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="index" type="integer" value="0" uimin="0" uimax="2" uniform="true" />
+      <output name="out" type="float" default="0.0" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <separate2>, <separate3>, <separate4> Supplemental Nodes
@@ -4631,42 +2285,14 @@
     Node: <blur>
     A gaussian-falloff blur.
   -->
-  <nodedef name="ND_blur_float" node="blur" nodegroup="convolution2d">
-    <input name="in" type="float" value="0.0" />
-    <input name="size" type="float" value="0.0" />
-    <input name="filtertype" type="string" value="box" enum="box,gaussian" uniform="true" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_blur_color3" node="blur" nodegroup="convolution2d">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="size" type="float" value="0.0" />
-    <input name="filtertype" type="string" value="box" enum="box,gaussian" uniform="true" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_blur_color4" node="blur" nodegroup="convolution2d">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="size" type="float" value="0.0" />
-    <input name="filtertype" type="string" value="box" enum="box,gaussian" uniform="true" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_blur_vector2" node="blur" nodegroup="convolution2d">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="size" type="float" value="0.0" />
-    <input name="filtertype" type="string" value="box" enum="box,gaussian" uniform="true" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_blur_vector3" node="blur" nodegroup="convolution2d">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="size" type="float" value="0.0" />
-    <input name="filtertype" type="string" value="box" enum="box,gaussian" uniform="true" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_blur_vector4" node="blur" nodegroup="convolution2d">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="size" type="float" value="0.0" />
-    <input name="filtertype" type="string" value="box" enum="box,gaussian" uniform="true" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_blur" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_blur_@typeName@" node="blur" nodegroup="convolution2d">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="size" type="float" value="0.0" />
+      <input name="filtertype" type="string" value="box" enum="box,gaussian" uniform="true" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <heighttonormal>
@@ -4729,85 +2355,12 @@
     Node: <dot>
     No-op; passes its input to the output unchanged.
   -->
-  <nodedef name="ND_dot_float" node="dot" nodegroup="organization">
-    <input name="in" type="float" value="0.0" />
-    <input name="note" type="string" value="" uniform="true" />
-    <output name="out" type="float" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_dot_color3" node="dot" nodegroup="organization">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="note" type="string" value="" uniform="true" />
-    <output name="out" type="color3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_dot_color4" node="dot" nodegroup="organization">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="note" type="string" value="" uniform="true" />
-    <output name="out" type="color4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_dot_vector2" node="dot" nodegroup="organization">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="note" type="string" value="" uniform="true" />
-    <output name="out" type="vector2" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_dot_vector3" node="dot" nodegroup="organization">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="note" type="string" value="" uniform="true" />
-    <output name="out" type="vector3" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_dot_vector4" node="dot" nodegroup="organization">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="note" type="string" value="" uniform="true" />
-    <output name="out" type="vector4" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_dot_boolean" node="dot" nodegroup="organization">
-    <input name="in" type="boolean" value="false" />
-    <input name="note" type="string" value="" uniform="true" />
-    <output name="out" type="boolean" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_dot_integer" node="dot" nodegroup="organization">
-    <input name="in" type="integer" value="0" />
-    <input name="note" type="string" value="" uniform="true" />
-    <output name="out" type="integer" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_dot_matrix33" node="dot" nodegroup="organization">
-    <input name="in" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="note" type="string" value="" uniform="true" />
-    <output name="out" type="matrix33" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_dot_matrix44" node="dot" nodegroup="organization">
-    <input name="in" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="note" type="string" value="" uniform="true" />
-    <output name="out" type="matrix44" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_dot_string" node="dot" nodegroup="organization">
-    <input name="in" type="string" value="" />
-    <input name="note" type="string" value="" uniform="true" />
-    <output name="out" type="string" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_dot_filename" node="dot" nodegroup="organization">
-    <input name="in" type="filename" value="" />
-    <input name="note" type="string" value="" uniform="true" />
-    <output name="out" type="filename" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_dot_surfaceshader" node="dot" nodegroup="organization">
-    <input name="in" type="surfaceshader" value="" />
-    <input name="note" type="string" value="" uniform="true" />
-    <output name="out" type="surfaceshader" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_dot_displacementshader" node="dot" nodegroup="organization">
-    <input name="in" type="displacementshader" value="" />
-    <input name="note" type="string" value="" uniform="true" />
-    <output name="out" type="displacementshader" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_dot_volumeshader" node="dot" nodegroup="organization">
-    <input name="in" type="volumeshader" value="" />
-    <input name="note" type="string" value="" uniform="true" />
-    <output name="out" type="volumeshader" defaultinput="in" />
-  </nodedef>
-  <nodedef name="ND_dot_lightshader" node="dot" nodegroup="organization">
-    <input name="in" type="lightshader" value="" />
-    <input name="note" type="string" value="" uniform="true" />
-    <output name="out" type="lightshader" defaultinput="in" />
-  </nodedef>
+  <template name="TP_ND_dot" varName="typeName" options="float, color3, color4, vector2, vector3, vector4, boolean, integer, matrix33, matrix44, filename, string, surfaceshader, displacementshader, volumeshader, lightshader">
+    <nodedef name="ND_dot_@typeName@" node="dot" nodegroup="organization">
+      <input name="in" type="@typeName@" value="Value:zero" />
+      <input name="note" type="string" value="" uniform="true" />
+      <output name="out" type="@typeName@" defaultinput="in" />
+    </nodedef>
+  </template>
 
 </materialx>

--- a/source/MaterialXBuildTools/buildLibrary/Main.cpp
+++ b/source/MaterialXBuildTools/buildLibrary/Main.cpp
@@ -67,28 +67,26 @@ void replaceNamedValues(mx::DocumentPtr doc, mx::ConstDocumentPtr stdlib)
             continue;
         }
 
-        if (!port->hasValueString())
-        {
-            continue;
-        }
+        mx::StringVec const& attributeNames = port->getAttributeNames();
+        for (std::string const& attrName: attributeNames) {
+            std::string const& valueStr = port->getAttribute(attrName);
 
-        auto valueStr = port->getValueString();
-        if (mx::stringStartsWith(valueStr, typeValuePrefix))
-        {
-
-            auto typeDef = stdlib->getTypeDef(port->getType());
-            if (!typeDef)
+            if (mx::stringStartsWith(valueStr, typeValuePrefix))
             {
-                throw mx::Exception("Unable to find typeDef '"+port->getType()+"'");
-            }
+                auto typeDef = stdlib->getTypeDef(port->getType());
+                if (!typeDef)
+                {
+                    throw mx::Exception("Unable to find typeDef '"+port->getType()+"'");
+                }
 
-            auto valueNameStr = valueStr.substr(typeValuePrefix.size());
-            if (!typeDef->hasAttribute(valueNameStr))
-            {
-                throw mx::Exception("Unable to find named value '"+valueNameStr+"' for type '"+typeDef->getName()+"'");
-            }
+                auto valueNameStr = valueStr.substr(typeValuePrefix.size());
+                if (!typeDef->hasAttribute(valueNameStr))
+                {
+                    throw mx::Exception("Unable to find named value '"+valueNameStr+"' for type '"+typeDef->getName()+"'");
+                }
 
-            port->setValueString(typeDef->getAttribute(valueNameStr));
+                port->setAttribute(attrName, typeDef->getAttribute(valueNameStr));
+            }
         }
     }
 }


### PR DESCRIPTION
This fills out the rest of the stdlib with templates, except for nodes where templating would not reduce the number of definitions (i.e. one template would generate exactly one nodedef). If we want to have _everything_ templated regardless, I can do that, let me know.

I've also made buildLibrary do the Value: replacement on all attributes on all ports so it can do out defaults, ui hints etc.

I've checked the output with a custom diffing tool and the remaining diffs are inconsequential ("0,0" vs "0.0,0.0" etc) with the exception of the atan2 nodes different in their defaults between types. Diff generated by the latest commit here is at the bottom of this message.

Couple of annoyances:
- I had to add "Value:half" for the contrast node's pivot. Maybe a better solution here would be "Broadcast(<value>)", e.g. "Broadcast(0.5)" - dunno what the impl of that would be like though. It's a bit ugly currently but not the end of the world imo
- The noise nodes' color3 and color4 variants take a vector3 or vector4 amplitude for some reason...
- extract uses uimax set to the rank of the input, so breaks templating unless we add something specifically for that

Diff:
```
ChangeAttribute { node: "ND_atan2_vector3.iny", attr: "value", value_l: "0.0,0.0,0.0", value_r: "1.0,1.0,1.0" }
ChangeAttribute { node: "ND_atan2_vector3.inx", attr: "value", value_l: "1.0,1.0,1.0", value_r: "0.0,0.0,0.0" }
ChangeAttribute { node: "ND_convert_color4_surfaceshader", attr: "doc", value_l: "Convert color4 to shader", value_r: "Convert color4  to shader" }
ChangeAttribute { node: "ND_convert_color4_surfaceshader.in", attr: "value", value_l: "0.0,0.0,0.0,0.0", value_r: "0,0,0,0" }
ChangeAttribute { node: "ND_dot_matrix33.in", attr: "value", value_l: "0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0", value_r: "1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0" }
ChangeAttribute { node: "ND_convert_float_surfaceshader.in", attr: "value", value_l: "0.0", value_r: "0" }
ChangeAttribute { node: "ND_convert_vector4_surfaceshader.in", attr: "value", value_l: "0.0,0.0,0.0,0.0", value_r: "0,0,0,0" }
DeleteAttribute { node: "ND_randomfloat_integer.in", attr: "doc" }
DeleteAttribute { node: "ND_randomfloat_integer.min", attr: "doc" }
DeleteAttribute { node: "ND_randomfloat_integer.max", attr: "doc" }
DeleteAttribute { node: "ND_randomfloat_integer.seed", attr: "doc" }
ChangeAttribute { node: "ND_dot_matrix44.in", attr: "value", value_l: "0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0", value_r: "1.0,0.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,0.0,1.0" }
ChangeAttribute { node: "ND_colorcorrect_color3.in", attr: "value", value_l: "1.0,1.0,1.0", value_r: "1,1,1" }
ChangeAttribute { node: "ND_mix_vector2_vector2.mix", attr: "uisoftmin", value_l: "0.0, 0.0", value_r: "0,0" }
ChangeAttribute { node: "ND_mix_vector2_vector2.mix", attr: "uisoftmax", value_l: "1.0, 1.0", value_r: "1,1" }
ChangeAttribute { node: "ND_mix_vector4_vector4.mix", attr: "uisoftmin", value_l: "0.0, 0.0, 0.0, 0.0", value_r: "0,0,0,0" }
ChangeAttribute { node: "ND_mix_vector4_vector4.mix", attr: "uisoftmax", value_l: "1.0, 1.0, 1.0, 1.0", value_r: "1,1,1,1" }
ChangeAttribute { node: "ND_mix_color3_color3.mix", attr: "uisoftmin", value_l: "0.0, 0.0, 0.0", value_r: "0,0,0" }
ChangeAttribute { node: "ND_mix_color3_color3.mix", attr: "uisoftmax", value_l: "1.0, 1.0, 1.0", value_r: "1,1,1" }
ChangeAttribute { node: "ND_mix_color4_color4.mix", attr: "uisoftmin", value_l: "0.0, 0.0, 0.0, 0.0", value_r: "0,0,0,0" }
ChangeAttribute { node: "ND_mix_color4_color4.mix", attr: "uisoftmax", value_l: "1.0, 1.0, 1.0, 1.0", value_r: "1,1,1,1" }
ChangeAttribute { node: "ND_convert_vector2_surfaceshader.in", attr: "value", value_l: "0.0,0.0", value_r: "0,0" }
ChangeAttribute { node: "ND_atan2_vector4.inx", attr: "value", value_l: "1.0,1.0,1.0,1.0", value_r: "0.0,0.0,0.0,0.0" }
ChangeAttribute { node: "ND_atan2_vector4.iny", attr: "value", value_l: "0.0,0.0,0.0,0.0", value_r: "1.0,1.0,1.0,1.0" }
ChangeAttribute { node: "ND_atan2_vector2.iny", attr: "value", value_l: "0.0,0.0", value_r: "1.0,1.0" }
ChangeAttribute { node: "ND_atan2_vector2.inx", attr: "value", value_l: "1.0,1.0", value_r: "0.0,0.0" }
ChangeAttribute { node: "ND_colorcorrect_color4.in", attr: "value", value_l: "1.0,1.0,1.0,1.0", value_r: "1,1,1,0" }
ChangeAttribute { node: "ND_convert_color3_surfaceshader.in", attr: "value", value_l: "0.0,0.0,0.0", value_r: "0,0,0" }
ChangeAttribute { node: "ND_randomcolor_float.in", attr: "uisoftmax", value_l: "10", value_r: "10.0" }
ChangeAttribute { node: "ND_mix_vector3_vector3.mix", attr: "uisoftmax", value_l: "1.0, 1.0, 1.0", value_r: "1,1,1" }
ChangeAttribute { node: "ND_mix_vector3_vector3.mix", attr: "uisoftmin", value_l: "0.0, 0.0, 0.0", value_r: "0,0,0" }
ChangeAttribute { node: "ND_convert_vector3_surfaceshader", attr: "doc", value_l: "Convert vector3 to shader", value_r: "Convert vector2 to shader" }
ChangeAttribute { node: "ND_convert_vector3_surfaceshader.in", attr: "value", value_l: "0.0,0.0,0.0", value_r: "0,0,0" }

```